### PR TITLE
Add black plane display function

### DIFF
--- a/src/black_plane.py
+++ b/src/black_plane.py
@@ -1,0 +1,10 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+def show_black_plane():
+    """Display an entirely black plane using matplotlib."""
+    black = np.zeros((10, 10, 3))
+    plt.imshow(black)
+    plt.axis('off')
+    plt.show()
+


### PR DESCRIPTION
## Summary
- implement `src/black_plane.py` with `show_black_plane` that uses matplotlib to display an all-black plane

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686459c1be88833187dad8dbbe10ea95