### PR TITLE
Add zoom support across drawing functions

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -9,10 +9,14 @@ def main():
     screen = pygame.display.set_mode((config.WINDOW_WIDTH, config.WINDOW_HEIGHT))
     pygame.display.set_caption("VastVoid")
 
-    sectors = create_sectors(config.GRID_SIZE, config.SECTOR_WIDTH, config.SECTOR_HEIGHT)
+    sectors = create_sectors(
+        config.GRID_SIZE, config.SECTOR_WIDTH, config.SECTOR_HEIGHT
+    )
     world_width = config.GRID_SIZE * config.SECTOR_WIDTH
     world_height = config.GRID_SIZE * config.SECTOR_HEIGHT
     ship = Ship(world_width // 2, world_height // 2)
+
+    zoom = 1.0
 
     clock = pygame.time.Clock()
     running = True
@@ -21,6 +25,11 @@ def main():
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 running = False
+            elif event.type == pygame.KEYDOWN:
+                if event.key == pygame.K_q:
+                    zoom = max(0.1, zoom - 0.1)
+                elif event.key == pygame.K_e:
+                    zoom += 0.1
 
         keys = pygame.key.get_pressed()
         ship.update(keys, dt, world_width, world_height, sectors)
@@ -31,7 +40,7 @@ def main():
         offset_x = ship.x - config.WINDOW_WIDTH // 2
         offset_y = ship.y - config.WINDOW_HEIGHT // 2
         for sector in sectors:
-            sector.draw(screen, offset_x, offset_y)
+            sector.draw(screen, offset_x, offset_y, zoom)
         ship.draw(screen)
 
         pygame.display.flip()

--- a/src/planet.py
+++ b/src/planet.py
@@ -21,10 +21,17 @@ class Planet:
         self.x = self.star.x + self.distance * math.cos(self.angle)
         self.y = self.star.y + self.distance * math.sin(self.angle)
 
-    def draw(self, screen: pygame.Surface, offset_x: float = 0, offset_y: float = 0) -> None:
+    def draw(
+        self,
+        screen: pygame.Surface,
+        offset_x: float = 0,
+        offset_y: float = 0,
+        zoom: float = 1.0,
+    ) -> None:
+        scaled_radius = max(1, int(self.radius * zoom))
         pygame.draw.circle(
             screen,
             self.color,
-            (int(self.x - offset_x), int(self.y - offset_y)),
-            self.radius,
+            (int((self.x - offset_x) * zoom), int((self.y - offset_y) * zoom)),
+            scaled_radius,
         )

--- a/src/sector.py
+++ b/src/sector.py
@@ -21,9 +21,15 @@ class Sector:
         for system in self.systems:
             system.update()
 
-    def draw(self, screen: pygame.Surface, offset_x: float, offset_y: float) -> None:
+    def draw(
+        self,
+        screen: pygame.Surface,
+        offset_x: float,
+        offset_y: float,
+        zoom: float = 1.0,
+    ) -> None:
         for system in self.systems:
-            system.draw(screen, offset_x, offset_y)
+            system.draw(screen, offset_x, offset_y, zoom)
 
     def collides_with_point(self, x: float, y: float, radius: float) -> bool:
         if not (self.x <= x <= self.x + self.width and self.y <= y <= self.y + self.height):

--- a/src/star.py
+++ b/src/star.py
@@ -9,11 +9,18 @@ class Star:
         self.radius = radius
         self.color = color
 
-    def draw(self, screen: pygame.Surface, offset_x: float = 0, offset_y: float = 0) -> None:
-        """Draw the star applying an optional camera offset."""
+    def draw(
+        self,
+        screen: pygame.Surface,
+        offset_x: float = 0,
+        offset_y: float = 0,
+        zoom: float = 1.0,
+    ) -> None:
+        """Draw the star applying an optional camera offset and zoom."""
+        scaled_radius = max(1, int(self.radius * zoom))
         pygame.draw.circle(
             screen,
             self.color,
-            (int(self.x - offset_x), int(self.y - offset_y)),
-            self.radius,
+            (int((self.x - offset_x) * zoom), int((self.y - offset_y) * zoom)),
+            scaled_radius,
         )

--- a/src/star_system.py
+++ b/src/star_system.py
@@ -45,15 +45,24 @@ class StarSystem:
                 return True
         return False
 
-    def draw(self, screen: pygame.Surface, offset_x: float = 0, offset_y: float = 0) -> None:
-        self.star.draw(screen, offset_x, offset_y)
+    def draw(
+        self,
+        screen: pygame.Surface,
+        offset_x: float = 0,
+        offset_y: float = 0,
+        zoom: float = 1.0,
+    ) -> None:
+        self.star.draw(screen, offset_x, offset_y, zoom)
         for planet in self.planets:
             # Draw orbit path for visualization
             pygame.draw.circle(
                 screen,
                 (80, 80, 120),
-                (int(self.star.x - offset_x), int(self.star.y - offset_y)),
-                int(planet.distance),
+                (
+                    int((self.star.x - offset_x) * zoom),
+                    int((self.star.y - offset_y) * zoom),
+                ),
+                int(planet.distance * zoom),
                 1,
             )
-            planet.draw(screen, offset_x, offset_y)
+            planet.draw(screen, offset_x, offset_y, zoom)


### PR DESCRIPTION
## Summary
- implement zoom controls in main game loop using Q/E keys
- propagate zoom to sector, star system, star and planet draw methods
- scale star, planet and orbital rendering by zoom factor

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68647cbd77c8833188fad0b6d49e6037