### PR TITLE
Fix zoom centering on ship

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -37,8 +37,8 @@ def main():
             sector.update()
 
         screen.fill(config.BACKGROUND_COLOR)
-        offset_x = ship.x - config.WINDOW_WIDTH // 2
-        offset_y = ship.y - config.WINDOW_HEIGHT // 2
+        offset_x = ship.x - config.WINDOW_WIDTH / (2 * zoom)
+        offset_y = ship.y - config.WINDOW_HEIGHT / (2 * zoom)
         for sector in sectors:
             sector.draw(screen, offset_x, offset_y, zoom)
         ship.draw(screen)


### PR DESCRIPTION
## Summary
- keep viewport centered on the ship when zooming

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68647e895f708331aca3e6f3d747deb5