### PR TITLE
Allow ship to scale with zoom

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -41,7 +41,7 @@ def main():
         offset_y = ship.y - config.WINDOW_HEIGHT / (2 * zoom)
         for sector in sectors:
             sector.draw(screen, offset_x, offset_y, zoom)
-        ship.draw(screen)
+        ship.draw(screen, zoom)
 
         pygame.display.flip()
 

--- a/src/ship.py
+++ b/src/ship.py
@@ -50,11 +50,13 @@ class Ship:
                 return True
         return False
 
-    def draw(self, screen: pygame.Surface) -> None:
+    def draw(self, screen: pygame.Surface, zoom: float = 1.0) -> None:
+        """Draw the ship scaled by a non-linear factor of the zoom level."""
+        size = max(1, int(config.SHIP_SIZE * zoom ** 0.5))
         ship_rect = pygame.Rect(
-            config.WINDOW_WIDTH // 2 - config.SHIP_SIZE // 2,
-            config.WINDOW_HEIGHT // 2 - config.SHIP_SIZE // 2,
-            config.SHIP_SIZE,
-            config.SHIP_SIZE,
+            config.WINDOW_WIDTH // 2 - size // 2,
+            config.WINDOW_HEIGHT // 2 - size // 2,
+            size,
+            size,
         )
         pygame.draw.rect(screen, config.SHIP_COLOR, ship_rect)


### PR DESCRIPTION
## Summary
- tweak `Ship.draw` to grow with zoom but slower than other objects
- pass zoom factor when drawing the ship

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686483704b60833188c111101756e0a1