### PR TITLE
Implement camera pan and ship boost

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -12,3 +12,14 @@ ORBIT_SPEED_FACTOR = 0.005  # base factor used to calculate orbital speed
 SECTOR_WIDTH = 2000
 SECTOR_HEIGHT = 2000
 GRID_SIZE = 3
+
+# Minimum distance allowed between star systems when generated
+MIN_SYSTEM_DISTANCE = 400
+
+# Ship boost settings
+BOOST_MULTIPLIER = 2.0  # speed multiplier when boost is active
+BOOST_DURATION = 2.0    # seconds of boost
+BOOST_RECHARGE = 10.0   # seconds to fully recharge boost
+
+# Camera speed when planning a route
+CAMERA_PAN_SPEED = 500  # pixels per second

--- a/src/sector.py
+++ b/src/sector.py
@@ -1,6 +1,8 @@
 import random
+import math
 import pygame
 from star_system import StarSystem
+import config
 
 class Sector:
     """Large region containing multiple star systems."""
@@ -13,9 +15,17 @@ class Sector:
         num_systems = random.randint(3, 4)
         self.systems = []
         for _ in range(num_systems):
-            sx = random.randint(self.x + 100, self.x + self.width - 100)
-            sy = random.randint(self.y + 100, self.y + self.height - 100)
-            self.systems.append(StarSystem(sx, sy))
+            for _ in range(100):  # attempt placement with spacing
+                sx = random.randint(self.x + 100, self.x + self.width - 100)
+                sy = random.randint(self.y + 100, self.y + self.height - 100)
+                too_close = False
+                for system in self.systems:
+                    if math.hypot(system.star.x - sx, system.star.y - sy) < config.MIN_SYSTEM_DISTANCE:
+                        too_close = True
+                        break
+                if not too_close:
+                    self.systems.append(StarSystem(sx, sy))
+                    break
 
     def update(self) -> None:
         for system in self.systems:

--- a/src/ui.py
+++ b/src/ui.py
@@ -63,14 +63,15 @@ class RoutePlanner:
         self.active = False
         self.destination = None
 
-    def handle_event(self, event, sectors: list, ship, zoom: float) -> None:
+    def handle_event(self, event, sectors: list, camera_pos, zoom: float) -> None:
+        """Process events while selecting a destination."""
         if not self.active:
             return
         if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
             self.cancel()
         elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
-            offset_x = ship.x - config.WINDOW_WIDTH / (2 * zoom)
-            offset_y = ship.y - config.WINDOW_HEIGHT / (2 * zoom)
+            offset_x = camera_pos[0] - config.WINDOW_WIDTH / (2 * zoom)
+            offset_y = camera_pos[1] - config.WINDOW_HEIGHT / (2 * zoom)
             world_x = event.pos[0] / zoom + offset_x
             world_y = event.pos[1] / zoom + offset_y
             for sector in sectors:


### PR DESCRIPTION
## Summary
- avoid star systems spawning too close in a sector
- add ship boost mechanic with rechargeable bar
- allow panning camera when planning a route
- show boost charge bar on screen

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6864914eedbc8331a57f74a4dca09932