### PR TITLE
Add character fraction selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ orbiting planets.
 The core game classes now live in separate modules within `src` and are
 initialized from a single entry point (`main.py`).
 
+## Character creation
+
+When starting the game you can personalise the player by entering a name,
+age, species and a **fraction** (faction). Five fictional fractions are
+available, each with a short description and a small boost for its members.
+
 ## Running the game
 
 ```bash

--- a/src/character.py
+++ b/src/character.py
@@ -1,5 +1,6 @@
 import pygame
 import config
+from fraction import FRACTIONS, Fraction
 
 class Alien:
     """Basic Alien species."""
@@ -18,10 +19,11 @@ class Robot:
 
 class Player:
     """The player controlled character."""
-    def __init__(self, name: str, age: int, species):
+    def __init__(self, name: str, age: int, species, fraction: Fraction):
         self.name = name
         self.age = age
         self.species = species
+        self.fraction = fraction
 
 
 def create_player(screen: pygame.Surface) -> Player:
@@ -30,8 +32,9 @@ def create_player(screen: pygame.Surface) -> Player:
     clock = pygame.time.Clock()
     name = ""
     age = ""
-    step = 0  # 0-name,1-age,2-species
+    step = 0  # 0-name,1-age,2-species,3-fraction
     species = None
+    fraction = None
 
     while True:
         for event in pygame.event.get():
@@ -64,7 +67,13 @@ def create_player(screen: pygame.Surface) -> Player:
                     elif key == 'r':
                         species = Robot()
                     if species:
-                        return Player(name, int(age or 0), species)
+                        step = 3
+                elif step == 3:
+                    if event.unicode.isdigit():
+                        index = int(event.unicode) - 1
+                        if 0 <= index < len(FRACTIONS):
+                            fraction = FRACTIONS[index]
+                            return Player(name, int(age or 0), species, fraction)
 
         screen.fill(config.BACKGROUND_COLOR)
         if step == 0:
@@ -77,10 +86,16 @@ def create_player(screen: pygame.Surface) -> Player:
             msg2 = font.render(age + "|", True, (255, 255, 255))
             screen.blit(msg1, (50, 100))
             screen.blit(msg2, (50, 140))
-        else:
+        elif step == 2:
             lines = [
                 "Choose species:",
                 "H - Human", "A - Alien", "R - Robot"]
+            for i, line in enumerate(lines):
+                msg = font.render(line, True, (255, 255, 255))
+                screen.blit(msg, (50, 100 + i * 30))
+        else:
+            lines = ["Choose fraction:"]
+            lines += [f"{i+1} - {frac.name}" for i, frac in enumerate(FRACTIONS)]
             for i, line in enumerate(lines):
                 msg = font.render(line, True, (255, 255, 255))
                 screen.blit(msg, (50, 100 + i * 30))

--- a/src/fraction.py
+++ b/src/fraction.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+
+@dataclass
+class Fraction:
+    """Represents a faction players can belong to."""
+    name: str
+    description: str
+    boost: str
+
+# Predefined fractions with simple boosts
+FRACTIONS = [
+    Fraction(
+        name="Solar Dominion",
+        description="Militaristic regime focused on expanding its stellar influence.",
+        boost="Increases ship speed slightly",
+    ),
+    Fraction(
+        name="Cosmic Guild",
+        description="Alliance of traders and engineers controlling most commerce routes.",
+        boost="Better prices at stations",
+    ),
+    Fraction(
+        name="Nebula Order",
+        description="Scholars dedicated to studying anomalies and black holes.",
+        boost="Sensors reveal planets from farther away",
+    ),
+    Fraction(
+        name="Pirate Clans",
+        description="Loose coalition of outlaws thriving on ambush and stealth.",
+        boost="Autopilot evades hazards more efficiently",
+    ),
+    Fraction(
+        name="Free Explorers",
+        description="Independent pilots seeking new frontiers beyond charted space.",
+        boost="Faster boost recharge",
+    ),
+]


### PR DESCRIPTION
## Summary
- introduce `fraction` module with 5 fictional factions
- extend `Player` to hold a chosen fraction
- update character creation flow to pick a fraction
- document the new customisation option

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68649aee5d108331a23275f52abdb465