### PR TITLE
Add ship selection and variety

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ initialized from a single entry point (`main.py`).
 When starting the game you can personalise the player by entering a name,
 age, species and a **fraction** (faction). Five fictional fractions are
 available, each with a short description and a small boost for its members.
+After the character is created you can also choose a starting ship from a
+small catalogue of models, each with its own brand and classification.
 
 ## Running the game
 

--- a/src/character.py
+++ b/src/character.py
@@ -19,11 +19,13 @@ class Robot:
 
 class Player:
     """The player controlled character."""
-    def __init__(self, name: str, age: int, species, fraction: Fraction):
+
+    def __init__(self, name: str, age: int, species, fraction: Fraction, ship_model=None):
         self.name = name
         self.age = age
         self.species = species
         self.fraction = fraction
+        self.ship_model = ship_model
 
 
 def create_player(screen: pygame.Surface) -> Player:

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,7 @@
 import pygame
 import math
 import config
-from ship import Ship
+from ship import Ship, choose_ship
 from sector import create_sectors
 from star import Star
 from planet import Planet
@@ -45,7 +45,10 @@ def main():
         blackholes.extend(sector.blackholes)
     world_width = config.GRID_SIZE * config.SECTOR_WIDTH
     world_height = config.GRID_SIZE * config.SECTOR_HEIGHT
-    ship = Ship(world_width // 2, world_height // 2)
+
+    chosen_model = choose_ship(screen)
+    player.ship_model = chosen_model
+    ship = Ship(world_width // 2, world_height // 2, chosen_model)
 
     zoom = 1.0
     selected_object = None

--- a/src/names.py
+++ b/src/names.py
@@ -67,6 +67,20 @@ _STATION_NAMES = [
     "Pioneer Post"
 ]
 
+# Names for playable ships
+_SHIP_NAMES = [
+    "Valiant",
+    "Nebula Runner",
+    "Star Chaser",
+    "Celestial Wind",
+    "Lone Voyager",
+    "Solar Flare",
+    "Void Whisper",
+    "Quantum Drift",
+    "Cosmic Arrow",
+    "Eclipse Rider",
+]
+
 
 def _get_name(pool: list) -> str:
     """Return and remove a random name from a pool."""
@@ -90,6 +104,10 @@ def get_system_name() -> str:
 
 def get_station_name() -> str:
     return _get_name(_STATION_NAMES)
+
+
+def get_ship_name() -> str:
+    return _get_name(_SHIP_NAMES)
 
 
 PLANET_ENVIRONMENTS = [


### PR DESCRIPTION
## Summary
- expand names with ship name list
- define `ShipModel` and ship catalogue
- allow choosing a ship after character creation
- support different ship attributes
- document ship choice in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68649e23fe1c8331ab4feebf48c2d0dd