### PR TITLE
Fix landing reposition and slow approach

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -6,6 +6,7 @@ SHIP_SIZE = 20
 SHIP_ACCELERATION = 300  # pixels per second squared
 SHIP_FRICTION = 0.92  # velocity retained each frame
 AUTOPILOT_SPEED = 200  # pixels per second when auto moving
+PLANET_LANDING_SPEED = 100  # slower speed when approaching a planet
 
 ORBIT_SPEED_FACTOR = 0.005  # base factor used to calculate orbital speed
 

--- a/src/main.py
+++ b/src/main.py
@@ -59,7 +59,6 @@ def main():
     current_station = None
     current_surface = None
     approaching_planet = None
-    prev_ship_pos = None
     camera_x = ship.x
     camera_y = ship.y
 
@@ -74,9 +73,10 @@ def main():
                     running = False
                     break
                 if current_surface.handle_event(event):
+                    planet = current_surface.planet
                     current_surface = None
-                    ship.x, ship.y = prev_ship_pos
-                    prev_ship_pos = None
+                    ship.x = planet.x + planet.radius + 40
+                    ship.y = planet.y
                     camera_x = ship.x
                     camera_y = ship.y
                     break
@@ -193,7 +193,6 @@ def main():
                         )
                         if visit_rect.collidepoint(event.pos):
                             approaching_planet = selected_object
-                            prev_ship_pos = (ship.x, ship.y)
                             ship.start_autopilot(selected_object)
                             selected_object = None
                             continue

--- a/src/ship.py
+++ b/src/ship.py
@@ -2,6 +2,7 @@ import pygame
 import math
 from dataclasses import dataclass
 import config
+from planet import Planet
 from names import get_ship_name
 
 
@@ -124,6 +125,8 @@ class Ship:
         dy = dest_y - self.y
         distance = math.hypot(dx, dy)
         step = config.AUTOPILOT_SPEED * dt
+        if isinstance(self.autopilot_target, Planet):
+            step = config.PLANET_LANDING_SPEED * dt
         if distance <= step:
             self.x = dest_x
             self.y = dest_y


### PR DESCRIPTION
## Summary
- adjust speed when landing on a planet
- place ship next to the planet after leaving its surface

## Testing
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6864a410ca8883318c3e6176200fe171