### PR TITLE
Add inventory menu and window

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ from sector import create_sectors
 from star import Star
 from planet import Planet
 from station import SpaceStation
-from ui import DropdownMenu, RoutePlanner
+from ui import DropdownMenu, RoutePlanner, InventoryWindow
 from planet_surface import PlanetSurface
 from character import create_player
 
@@ -54,8 +54,9 @@ def main():
     zoom = 1.0
     selected_object = None
     info_font = pygame.font.Font(None, 20)
-    menu = DropdownMenu(10, 10, 100, 25, ["Plan Route"])
+    menu = DropdownMenu(10, 10, 100, 25, ["Plan Route", "Inventory"])
     route_planner = RoutePlanner()
+    inventory_window = None
     current_station = None
     current_surface = None
     approaching_planet = None
@@ -84,6 +85,19 @@ def main():
                 keys = pygame.key.get_pressed()
                 current_surface.update(keys, dt)
                 current_surface.draw(screen, info_font)
+                pygame.display.flip()
+                continue
+
+        if inventory_window:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    running = False
+                    break
+                if inventory_window.handle_event(event):
+                    inventory_window = None
+                    break
+            if inventory_window:
+                inventory_window.draw(screen, info_font)
                 pygame.display.flip()
                 continue
 
@@ -133,6 +147,8 @@ def main():
             selection = menu.handle_event(event)
             if selection == "Plan Route":
                 route_planner.start()
+            elif selection == "Inventory":
+                inventory_window = InventoryWindow(player)
 
             route_planner.handle_event(event, sectors, (camera_x, camera_y), zoom)
 

--- a/src/ui.py
+++ b/src/ui.py
@@ -110,3 +110,35 @@ class RoutePlanner:
                 text = font.render(line, True, (255, 255, 255))
                 screen.blit(text, (rect.x + 5, rect.y + 5 + i * 20))
 
+
+class InventoryWindow:
+    """Display the player's inventory in a simple window."""
+
+    def __init__(self, player) -> None:
+        self.player = player
+        self.close_rect = pygame.Rect(config.WINDOW_WIDTH - 110, 10, 100, 30)
+
+    def handle_event(self, event) -> bool:
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            if self.close_rect.collidepoint(event.pos):
+                return True
+        if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+            return True
+        return False
+
+    def draw(self, screen: pygame.Surface, font: pygame.font.Font) -> None:
+        screen.fill((20, 20, 40))
+        title = font.render("Inventory", True, (255, 255, 255))
+        screen.blit(title, (20, 20))
+        y = 60
+        for name, qty in self.player.inventory.items():
+            if qty > 0:
+                text = font.render(f"{name}: {qty}", True, (255, 255, 255))
+                screen.blit(text, (40, y))
+                y += 20
+        pygame.draw.rect(screen, (60, 60, 90), self.close_rect)
+        pygame.draw.rect(screen, (200, 200, 200), self.close_rect, 1)
+        exit_txt = font.render("Close", True, (255, 255, 255))
+        exit_rect = exit_txt.get_rect(center=self.close_rect.center)
+        screen.blit(exit_txt, exit_rect)
+


### PR DESCRIPTION
## Summary
- extend dropdown menu with Inventory option
- display player's items in new `InventoryWindow`
- handle inventory window events in main loop

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6864ad0c8884833188625043163bda82