### PR TITLE
Allow inventory and boat usage everywhere

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -73,6 +73,9 @@ def main():
                 if event.type == pygame.QUIT:
                     running = False
                     break
+                if event.type == pygame.KEYDOWN and event.key == pygame.K_i:
+                    inventory_window = InventoryWindow(player)
+                    continue
                 if current_surface.handle_event(event):
                     planet = current_surface.planet
                     current_surface = None
@@ -134,6 +137,9 @@ def main():
                     ship.x = current_station.x + current_station.radius + 40
                     current_station = None
                     continue
+                if event.type == pygame.KEYDOWN and event.key == pygame.K_i:
+                    inventory_window = InventoryWindow(player)
+                    continue
                 if (
                     event.type == pygame.MOUSEBUTTONDOWN
                     and event.button == 1
@@ -176,6 +182,8 @@ def main():
                     zoom += 0.1
                 elif event.key == pygame.K_ESCAPE:
                     selected_object = None
+                elif event.key == pygame.K_i:
+                    inventory_window = InventoryWindow(player)
             elif event.type == pygame.MOUSEBUTTONDOWN:
                 offset_x = camera_x - config.WINDOW_WIDTH / (2 * zoom)
                 offset_y = camera_y - config.WINDOW_HEIGHT / (2 * zoom)

--- a/src/planet_surface.py
+++ b/src/planet_surface.py
@@ -274,7 +274,7 @@ class PlanetSurface:
     def is_walkable(self, x: float, y: float) -> bool:
         """Return ``True`` if the coordinates correspond to a walkable cell."""
         if self.collision_mask and self.collision_mask.get_at((int(x), int(y))):
-            if self.boat_active and self._point_near_river(x, y):
+            if self.boat_active:
                 return True
             return False
         cx = int(x // self.cell)
@@ -293,10 +293,7 @@ class PlanetSurface:
             if event.key == pygame.K_b:
                 if self.boat_active:
                     self.boat_active = False
-                elif (
-                    self.player.inventory.get("boat", 0) > 0
-                    and self._point_near_river(self.explorer.x, self.explorer.y)
-                ):
+                elif self.player.inventory.get("boat", 0) > 0:
                     self.boat_active = True
         return False
 
@@ -305,8 +302,6 @@ class PlanetSurface:
         self.explorer.update(keys, dt, self.width, self.height)
         if not self.is_walkable(self.explorer.x, self.explorer.y):
             self.explorer.x, self.explorer.y = old_x, old_y
-        if self.boat_active and not self._point_near_river(self.explorer.x, self.explorer.y):
-            self.boat_active = False
         self.camera_x = self.explorer.x
         self.camera_y = self.explorer.y
         for pickup in self.pickups[:]:


### PR DESCRIPTION
## Summary
- open the inventory while exploring planets or in stations
- enable the boat anywhere so it lets the player move over water

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68655f43d498833193d57bb37208139d