### PR TITLE
Fix py_trees selector instantiation

### DIFF
--- a/src/enemy.py
+++ b/src/enemy.py
@@ -144,7 +144,7 @@ class Enemy:
         attack = Attack(self)
         pursue = Pursue(self)
         idle = Idle(self)
-        root = py_trees.composites.Selector("EnemyRoot")
+        root = py_trees.composites.Selector("EnemyRoot", memory=False)
         root.add_children([flee, attack, pursue, idle])
         self.tree = py_trees.trees.BehaviourTree(root)
 


### PR DESCRIPTION
## Summary
- add missing `memory` argument when building the enemy behavior tree

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68659779d0dc8331b06f314cedafb1d2