### PR TITLE
Enable learning enemies

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ flee. Actions inside the tree call the same ship methods as before so combat
 and navigation work exactly like the earlier state machine implementation.
 
 ### Learning enemies
-An experimental `LearningEnemy` class in `src/enemy_learning.py` replaces the
-behaviour tree with a simple Q-learning algorithm. Each enemy chooses actions
-like pursue or attack based on a learned Q-table updated every frame. Use the
-helper `create_learning_enemy()` to spawn this variant if you want opponents
-that adapt slightly to the player's tactics.
+Enemies now use the experimental `LearningEnemy` class from
+`src/enemy_learning.py`. It replaces the behaviour tree with a simple
+Q-learning algorithm so that each enemy chooses actions like pursue or attack
+based on a learned Q-table updated every frame. Enemies are spawned through the
+`create_learning_enemy()` helper by default and will adapt slightly to the
+player's tactics.

--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,7 @@ import math
 import random
 import config
 from ship import Ship, choose_ship
-from enemy import create_random_enemy
+from enemy_learning import create_learning_enemy
 from sector import create_sectors
 from wormhole import WormHole
 from star import Star
@@ -63,7 +63,7 @@ def main():
     num_enemies = random.randint(config.MIN_ENEMIES, config.MAX_ENEMIES)
     for _ in range(num_enemies):
         region = random.choice(sectors)
-        enemies.append(create_random_enemy(region))
+        enemies.append(create_learning_enemy(region))
 
     chosen_model = choose_ship(screen)
     player.ship_model = chosen_model


### PR DESCRIPTION
## Summary
- enable Q-learning opponents by using `create_learning_enemy`
- document that learning enemies are now the default

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6865a0efce74833190fd0d9e5ec907e0