### PR TITLE
Slow down shield regen, increase enemy fire rate

### DIFF
--- a/src/combat.py
+++ b/src/combat.py
@@ -53,7 +53,8 @@ class Projectile:
 class Shield:
     """Basic energy shield that absorbs damage and recharges over time."""
     max_strength: int = 100
-    recharge_rate: float = 10.0
+    # Regeneration slowed down so shields take longer to recover
+    recharge_rate: float = 1.0
     strength: float = field(init=False)
 
     def __post_init__(self) -> None:

--- a/src/enemy.py
+++ b/src/enemy.py
@@ -222,5 +222,6 @@ def create_random_enemy(region: Sector) -> Enemy:
     y = random.randint(region.y, region.y + region.height)
     enemy = Enemy(Ship(x, y, model), species, region)
     if enemy.ship.weapons:
-        enemy.ship.weapons[0].cooldown = 0.25
+        # Reduce cooldown so enemies fire more often
+        enemy.ship.weapons[0].cooldown = 0.1
     return enemy

--- a/src/enemy_learning.py
+++ b/src/enemy_learning.py
@@ -110,5 +110,6 @@ def create_learning_enemy(region):
     enemy = LearningEnemy(Ship(x, y, model), species, region)
     # make enemy weapons fire more frequently
     if enemy.ship.weapons:
-        enemy.ship.weapons[0].cooldown = 0.25
+        # Reduce cooldown so learning enemies fire more often
+        enemy.ship.weapons[0].cooldown = 0.1
     return enemy


### PR DESCRIPTION
## Summary
- slow down the shield's regeneration speed
- make enemies shoot more often, including learning enemies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865a4e223888331964c9a47c14ae426