### PR TITLE
Persist learning enemy Q-table

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,7 @@ Q-learning algorithm so that each enemy chooses actions like pursue or attack
 based on a learned Q-table updated every frame. Enemies are spawned through the
 `create_learning_enemy()` helper by default and will adapt slightly to the
 player's tactics.
+
+The Q-table for these enemies is saved to `learning_enemy_q_table.pkl` in the
+project root when the game exits. Spawning enemies load this file if present so
+their behaviour persists between sessions.

--- a/src/main.py
+++ b/src/main.py
@@ -510,6 +510,10 @@ def main():
 
         pygame.display.flip()
 
+    # Save learning data so enemies retain behavior between sessions
+    for enemy in enemies:
+        enemy.save_q_table()
+
     pygame.quit()
 
 


### PR DESCRIPTION
## Summary
- allow LearningEnemy to save and load its Q-table
- load the table when spawning new learning enemies
- save the table on exit so behaviour carries over
- document persistent enemy learning in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6865a5c49eb0833182a27fce0a41cb92