### PR TITLE
Add ability bar with new orbit skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,11 @@ The Q-table for these enemies is saved to `learning_enemy_q_table.pkl` in the
 project root when the game exits. Spawning enemies load this file if present so
 their behaviour persists between sessions.
 
-### Attack orbit
-Press **R** while near an enemy ship to start an attack orbit around it for
-five seconds. During this manoeuvre all of your shots automatically target the
-orbited enemy. Enemies may also force your ship into an orbit with a 10%
-chance when they attack, but boosting will break the effect.
+### Ability bar and attack orbit
+Five ability slots now appear at the bottom of the screen. The first slot shows
+the **Boost** ability which is still activated with the left **Shift** key. The
+second slot triggers the **Orbit** skill using the **R** key or by clicking the
+slot. When used, your ship orbits the nearest enemy at a reduced speed and
+automatically fires once per second for the duration of the manoeuvre. Enemies
+may still force your ship into an orbit with a 10% chance when they attack,
+but boosting will break the effect.

--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,7 @@ from wormhole import WormHole
 from star import Star
 from planet import Planet
 from station import SpaceStation
-from ui import DropdownMenu, RoutePlanner, InventoryWindow
+from ui import DropdownMenu, RoutePlanner, InventoryWindow, AbilityBar
 from planet_surface import PlanetSurface
 from character import create_player
 
@@ -74,6 +74,7 @@ def main():
     info_font = pygame.font.Font(None, 20)
     menu = DropdownMenu(10, 10, 100, 25, ["Plan Route", "Inventory"])
     route_planner = RoutePlanner()
+    ability_bar = AbilityBar()
     inventory_window = None
     current_station = None
     current_surface = None
@@ -215,6 +216,7 @@ def main():
                 inventory_window = InventoryWindow(player)
 
             route_planner.handle_event(event, sectors, (camera_x, camera_y), zoom)
+            ability_bar.handle_event(event, ship, enemies)
 
             if route_planner.destination:
                 if (
@@ -251,7 +253,7 @@ def main():
                             min_dist = d
                             nearest = en
                     if nearest and min_dist <= 350:
-                        ship.start_orbit(nearest.ship)
+                        ship.start_orbit(nearest.ship, speed=config.SHIP_ORBIT_SPEED * 0.5)
                 elif event.key == pygame.K_SPACE:
                     mx, my = pygame.mouse.get_pos()
                     offset_x = camera_x - config.WINDOW_WIDTH / (2 * zoom)
@@ -509,7 +511,7 @@ def main():
         hull_fill = int(bar_width * ship.hull / 100)
         if hull_fill > 0:
             pygame.draw.rect(screen, (150, 0, 0), (bar_x, hull_y, hull_fill, bar_height))
-
+        ability_bar.draw(screen, info_font)
         menu.draw(screen, info_font)
 
         if teleport_flash_timer > 0:


### PR DESCRIPTION
## Summary
- add ability bar UI with Boost and Orbit slots
- allow clicking slots to activate abilities
- slow orbit speed and auto-fire once per second
- document new ability bar feature in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865aca87efc8331a2bdcd3e563ab6d2