### PR TITLE
Improve orbit attack timing and add cooldown

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ their behaviour persists between sessions.
 Five ability slots now appear at the bottom of the screen. The first slot shows
 the **Boost** ability which is still activated with the left **Shift** key. The
 second slot triggers the **Orbit** skill using the **R** key or by clicking the
-slot. When used, your ship orbits the nearest enemy at a reduced speed and
-automatically fires once per second for the duration of the manoeuvre. Enemies
-may still force your ship into an orbit with a 10% chance when they attack,
-but boosting will break the effect.
+slot. When used, your ship orbits the nearest enemy at a reduced speed for five
+seconds and automatically fires once every second. After the orbit ends there
+is a short cooldown before it can be triggered again. Enemies may still force
+your ship into an orbit with a 10% chance when they attack, but boosting will
+break the effect.

--- a/src/config.py
+++ b/src/config.py
@@ -14,7 +14,8 @@ BOAT_SPEED_LAND = 60  # slow boat speed when on land
 BOAT_SPEED_WATER = 200  # slightly faster than walking when on water
 
 ORBIT_SPEED_FACTOR = 0.005  # base factor used to calculate orbital speed
-SHIP_ORBIT_SPEED = 2.5      # angular speed for attack orbits (radians per second)
+SHIP_ORBIT_SPEED = 1.5      # angular speed for attack orbits (radians per second)
+ORBIT_COOLDOWN = 5.0        # delay before a new orbit can be triggered
 
 SECTOR_WIDTH = 2000
 SECTOR_HEIGHT = 2000

--- a/src/ship.py
+++ b/src/ship.py
@@ -41,6 +41,7 @@ class Ship:
         self.orbit_angle = 0.0
         self.orbit_speed = config.SHIP_ORBIT_SPEED
         self.orbit_fire_timer = 0.0
+        self.orbit_cooldown = 0.0
         self.orbit_forced = False
         self.boost_charge = 1.0
         self.boost_time = 0.0
@@ -72,6 +73,8 @@ class Ship:
         sectors: list,
         blackholes: list | None = None,
     ) -> None:
+        if self.orbit_cooldown > 0:
+            self.orbit_cooldown = max(0.0, self.orbit_cooldown - dt)
         if self.orbit_time > 0 and self.orbit_target:
             self._update_orbit(dt)
             if self.boost_time > 0 and self.orbit_forced:
@@ -142,6 +145,8 @@ class Ship:
         speed: float | None = None,
     ) -> None:
         """Begin orbiting ``target`` for a short duration."""
+        if self.orbit_cooldown > 0 or self.orbit_time > 0:
+            return
         dx = self.x - target.x
         dy = self.y - target.y
         self.orbit_radius = math.hypot(dx, dy)
@@ -150,7 +155,7 @@ class Ship:
         self.orbit_time = duration
         self.orbit_forced = forced
         self.orbit_speed = speed if speed is not None else config.SHIP_ORBIT_SPEED
-        self.orbit_fire_timer = 1.0
+        self.orbit_fire_timer = 0.0
         self.autopilot_target = None
 
     def cancel_orbit(self) -> None:
@@ -159,6 +164,7 @@ class Ship:
         self.orbit_forced = False
         self.orbit_speed = config.SHIP_ORBIT_SPEED
         self.orbit_fire_timer = 0.0
+        self.orbit_cooldown = config.ORBIT_COOLDOWN
 
     def _update_autopilot(
         self,


### PR DESCRIPTION
## Summary
- make orbit text mention 5 second duration and cooldown
- reduce orbit speed and add ORBIT_COOLDOWN setting
- track orbit cooldown in `Ship`
- prevent orbit while on cooldown and fire immediately when orbit starts

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6865ae907a248331a541796fe69763f0