### PR TITLE
Fix orbit weapon timers

### DIFF
--- a/src/ship.py
+++ b/src/ship.py
@@ -75,18 +75,23 @@ class Ship:
     ) -> None:
         if self.orbit_cooldown > 0:
             self.orbit_cooldown = max(0.0, self.orbit_cooldown - dt)
+
+        # Always recharge shields and update weapon timers
+        self.shield.recharge(dt)
+        for weapon in self.weapons:
+            weapon.update(dt)
+
         if self.orbit_time > 0 and self.orbit_target:
             self._update_orbit(dt)
             if self.boost_time > 0 and self.orbit_forced:
                 self.cancel_orbit()
             return
+
         if self.autopilot_target:
             self._update_autopilot(dt, world_width, world_height, sectors, blackholes)
             return
+
         accel = config.SHIP_ACCELERATION * self.accel_factor
-        self.shield.recharge(dt)
-        for weapon in self.weapons:
-            weapon.update(dt)
         if self.boost_time > 0:
             self.boost_time -= dt
             if self.boost_time <= 0:


### PR DESCRIPTION
## Summary
- update ship weapons and shield recharge before orbit/autopilot checks

## Testing
- `python -m compileall -q src`
- `PYTHONPATH=src SDL_VIDEODRIVER=dummy python - <<'PY'
import pygame
from ship import Ship
pygame.init(); pygame.display.set_mode((1,1))
keys = pygame.key.get_pressed()
s = Ship(0,0)
class Dummy:
    def __init__(self,x,y): self.x=x; self.y=y
trg=Dummy(100,0)
s.start_orbit(trg,duration=3.0)
for i in range(5):
    s.update(keys,1.0,1000,1000,[])
    print(i+1,len(s.projectiles))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6865b16022b4833184c1aa4b0f98d07f