### PR TITLE
Add curved orbit projectiles with range limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,7 @@ second slot triggers the **Orbit** skill using the **R** key or by clicking the
 slot. When used, your ship orbits the nearest enemy at a reduced speed for five
 seconds and automatically fires once every second. After the orbit ends there
 is a short cooldown before it can be triggered again.
+
+Projectiles now vanish after travelling around 1200 pixels. Shots fired during
+an orbit curve slightly thanks to a gentle angular adjustment applied every
+frame.

--- a/src/config.py
+++ b/src/config.py
@@ -17,6 +17,8 @@ ORBIT_SPEED_FACTOR = 0.005  # base factor used to calculate orbital speed
 SHIP_ORBIT_SPEED = 1.5      # angular speed for attack orbits (radians per second)
 ORBIT_COOLDOWN = 5.0        # delay before a new orbit can be triggered
 ORBIT_PROJECTILE_SPEED_MULTIPLIER = 2.5  # bullet speed boost while orbiting
+ORBIT_PROJECTILE_CURVATURE = 0.5        # radians per second of bullet curve
+PROJECTILE_MAX_DISTANCE = 1200          # maximum distance a projectile can travel
 
 SECTOR_WIDTH = 2000
 SECTOR_HEIGHT = 2000

--- a/src/ship.py
+++ b/src/ship.py
@@ -286,7 +286,15 @@ class Ship:
             tx, ty = self._predict_target_position(target, bullet_speed)
             if weapon.can_fire():
                 weapon._timer = 0.0
-                proj = Projectile(self.x, self.y, tx, ty, bullet_speed, weapon.damage)
+                proj = Projectile(
+                    self.x,
+                    self.y,
+                    tx,
+                    ty,
+                    bullet_speed,
+                    weapon.damage,
+                    curvature=config.ORBIT_PROJECTILE_CURVATURE,
+                )
         else:
             proj = weapon.fire(self.x, self.y, tx, ty)
         if proj:
@@ -295,7 +303,8 @@ class Ship:
     def _update_projectiles(self, dt: float, world_width: int, world_height: int) -> None:
         for proj in list(self.projectiles):
             proj.update(dt)
-            if not (0 <= proj.x <= world_width and 0 <= proj.y <= world_height):
+            out_of_bounds = not (0 <= proj.x <= world_width and 0 <= proj.y <= world_height)
+            if proj.expired() or out_of_bounds:
                 self.projectiles.remove(proj)
 
     def take_damage(self, amount: float) -> None:


### PR DESCRIPTION
## Summary
- support projectile curvature and max range
- curve bullets in orbit mode and remove expired shots
- document the new behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6865c35666e08331be81a1f79a2292fa