### PR TITLE
Use homing shots during orbit

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,6 @@ slot. When used, your ship orbits the nearest enemy at a reduced speed for five
 seconds and automatically fires once every second. After the orbit ends there
 is a short cooldown before it can be triggered again.
 
-Projectiles now vanish after travelling around 1200 pixels. Shots fired during
-an orbit curve slightly thanks to a gentle angular adjustment applied every
-frame.
-Press **H** to launch a guided projectile that continually turns towards the
-nearest enemy.
+Projectiles now vanish after travelling around 1200 pixels. While orbiting an
+enemy, your ship automatically fires homing shots once per second that track
+the target. Normal shots are unaffected and travel in a straight line.

--- a/src/main.py
+++ b/src/main.py
@@ -254,16 +254,6 @@ def main():
                             nearest = en
                     if nearest and min_dist <= 350:
                         ship.start_orbit(nearest.ship, speed=config.SHIP_ORBIT_SPEED * 0.5)
-                elif event.key == pygame.K_h:
-                    nearest = None
-                    min_dist = float("inf")
-                    for en in enemies:
-                        d = math.hypot(en.ship.x - ship.x, en.ship.y - ship.y)
-                        if d < min_dist:
-                            min_dist = d
-                            nearest = en
-                    if nearest:
-                        ship.fire_homing(nearest.ship)
                 elif event.key == pygame.K_SPACE:
                     mx, my = pygame.mouse.get_pos()
                     offset_x = camera_x - config.WINDOW_WIDTH / (2 * zoom)

--- a/src/ship.py
+++ b/src/ship.py
@@ -221,7 +221,16 @@ class Ship:
         self.y = self.orbit_target.y + math.sin(self.orbit_angle) * self.orbit_radius
         self.orbit_fire_timer -= dt
         if self.orbit_fire_timer <= 0:
-            self.fire(self.orbit_target.x, self.orbit_target.y)
+            # Fire a homing projectile while orbiting
+            if self.weapons:
+                weapon = self.weapons[0]
+                if weapon.can_fire():
+                    weapon._timer = 0.0
+                    proj = weapon.fire_homing(self.x, self.y, self.orbit_target)
+                    if proj:
+                        proj.vx *= config.ORBIT_PROJECTILE_SPEED_MULTIPLIER
+                        proj.vy *= config.ORBIT_PROJECTILE_SPEED_MULTIPLIER
+                        self.projectiles.append(proj)
             self.orbit_fire_timer += 1.0
         if self.orbit_time <= 0:
             self.cancel_orbit()


### PR DESCRIPTION
## Summary
- orbiting now fires homing projectiles that travel faster
- remove manual homing shot keybind
- update README to describe the new orbit behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6865c68b892c8331a140f48890ca4a97