### PR TITLE
Enable enemy orbit capability

### DIFF
--- a/src/enemy_learning.py
+++ b/src/enemy_learning.py
@@ -104,6 +104,13 @@ class LearningEnemy(Enemy):
         action = self.choose_action(state)
         self.perform_action(action)
         self.ship.update(_NullKeys(), dt, world_width, world_height, sectors, blackholes)
+
+        if (
+            player_ship.boost_time > 0
+            and self.ship.orbit_target is player_ship
+            and self.ship.orbit_time > 0
+        ):
+            self.ship.cancel_orbit()
         reward = self.compute_reward()
         next_state = self._state()
         self.learn(state, action, reward, next_state)


### PR DESCRIPTION
## Summary
- let enemies start orbiting the player when close
- cancel enemy orbit if the player boosts
- do the same for learning enemies

## Testing
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6865cce3a9948331afef7296017ca478