### PR TITLE
Implement probabilistic enemy orbit behavior

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -60,3 +60,7 @@ MAX_ENEMIES = 12
 # 0.5, so enemies fire slightly faster but still allow the player to
 # dodge incoming shots.
 ENEMY_WEAPON_COOLDOWN = 0.3
+
+# How often enemies attempt an orbit attack
+ENEMY_ORBIT_INTERVAL = 10.0  # seconds between orbit attempts
+ENEMY_ORBIT_PROBABILITY = 0.2  # chance of starting an orbit each interval

--- a/src/enemy.py
+++ b/src/enemy.py
@@ -79,7 +79,10 @@ class Attack(_EnemyBehaviour):
         # If close enough, orbit the player instead of moving directly towards
         # them. This uses the same orbit parameters available to the player.
         if ship.orbit_time <= 0 and dist <= enemy.attack_range:
-            ship.start_orbit(player, speed=config.SHIP_ORBIT_SPEED * 0.5)
+            if enemy.orbit_timer <= 0:
+                enemy.orbit_timer = config.ENEMY_ORBIT_INTERVAL
+                if random.random() < config.ENEMY_ORBIT_PROBABILITY:
+                    ship.start_orbit(player, speed=config.SHIP_ORBIT_SPEED * 0.5)
         if ship.orbit_time <= 0:
             angle = math.atan2(dy, dx)
             dest_x = player.x - math.cos(angle) * 120
@@ -182,6 +185,11 @@ class Enemy:
     _wander_target: _Point | None = field(default=None, init=False, repr=False)
     player_ship: Ship | None = field(default=None, init=False, repr=False)
     tree: py_trees.trees.BehaviourTree | None = field(default=None, init=False, repr=False)
+    orbit_timer: float = field(
+        default=config.ENEMY_ORBIT_INTERVAL,
+        init=False,
+        repr=False,
+    )
 
     def __post_init__(self) -> None:
         self.build_tree()
@@ -209,6 +217,7 @@ class Enemy:
         """Update ship movement after behaviour tree tick."""
 
         self.player_ship = player_ship
+        self.orbit_timer = max(0.0, self.orbit_timer - dt)
         if self.tree:
             self.tree.tick()
 


### PR DESCRIPTION
## Summary
- configure orbit attempt probability and interval
- add orbit timer handling to `Enemy`
- only start an enemy orbit when the timer expires and chance check succeeds

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6865cdb3ba5c8331981c538624a8929b