### PR TITLE
Adjust enemy orbit parameters

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -62,5 +62,5 @@ MAX_ENEMIES = 12
 ENEMY_WEAPON_COOLDOWN = 0.3
 
 # How often enemies attempt an orbit attack
-ENEMY_ORBIT_INTERVAL = 10.0  # seconds between orbit attempts
-ENEMY_ORBIT_PROBABILITY = 0.2  # chance of starting an orbit each interval
+ENEMY_ORBIT_INTERVAL = 12.0  # seconds between orbit attempts
+ENEMY_ORBIT_PROBABILITY = 0.35  # chance of starting an orbit each interval

--- a/src/enemy.py
+++ b/src/enemy.py
@@ -177,7 +177,7 @@ class Enemy:
     ship: Ship
     species: object
     region: Sector
-    attack_range: float = 350.0
+    attack_range: float = 385.0
     detection_range: float = 800.0
     flee_threshold: int = 30
     state: str = field(default="idle", init=False)


### PR DESCRIPTION
## Summary
- tune enemy orbit interval to 12 seconds
- increase orbit probability to 35%
- extend enemy attack range by 10%

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6865cf7a3c488331823777ebf5898894