### PR TITLE
Implement persistent drones with hitboxes

### DIFF
--- a/src/combat.py
+++ b/src/combat.py
@@ -353,15 +353,21 @@ class TimedMine:
 
 
 class Drone:
-    """Autonomous drone that orbits the owner and fires at enemies."""
+    """Autonomous drone that orbits the owner and fires at enemies.
 
-    def __init__(self, owner, hp: float = 10.0, lifetime: float = 8.0) -> None:
+    Drones persist until their hit points reach zero rather than expiring
+    after a timed duration. A small size value defines a hitbox so enemy
+    projectiles can damage them.
+    """
+
+    def __init__(self, owner, hp: float = 5.0, lifetime: float = float("inf")) -> None:
         self.owner = owner
         self.angle = 0.0
         # Increased orbit range so drones keep a bit more distance
         self.radius = owner.size * 3
         self.hp = hp
         self.lifetime = lifetime
+        self.size = 10
         self.projectiles: List[Projectile] = []
         # Slightly faster fire rate
         self.fire_cooldown = 0.8

--- a/src/ship.py
+++ b/src/ship.py
@@ -384,6 +384,19 @@ class Ship:
                             en.ship.take_damage(proj.damage)
                             obj.projectiles.remove(proj)
                             break
+                drone_rect = pygame.Rect(
+                    obj.x - obj.size / 2,
+                    obj.y - obj.size / 2,
+                    obj.size,
+                    obj.size,
+                )
+                for en in enemies or []:
+                    for proj in list(en.ship.projectiles):
+                        if drone_rect.collidepoint(proj.x, proj.y):
+                            obj.hp -= proj.damage
+                            en.ship.projectiles.remove(proj)
+                            if obj.hp <= 0:
+                                break
                 if obj.expired():
                     self.specials.remove(obj)
 


### PR DESCRIPTION
## Summary
- keep drones alive until destroyed by setting infinite lifetime
- add a size attribute to use as a hitbox
- damage drones when enemy projectiles collide with them

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6865f54a1e008331a226f83262104de4