### PR TITLE
Increase wormhole pair distance

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ The original example scripts (`black_plane.py`, `nave.py`, `space_objects.py`
 and `colliding_star_systems.py`) remain in the `src` directory for reference.
 
 Wormholes now appear at least once in every generated universe, allowing
-instant travel between two distant points.
+instant travel between two distant points. The two ends of a pair are
+placed far apart thanks to the `WORMHOLE_PAIR_MIN_DISTANCE` setting.
 
 ### Enemy AI
 

--- a/src/config.py
+++ b/src/config.py
@@ -46,6 +46,8 @@ BLACKHOLE_RADIUS = 25         # radius of the dangerous core
 # Worm hole settings
 WORMHOLE_CHANCE = 0.05       # probability of a sector containing a wormhole pair
 WORMHOLE_MIN_DISTANCE = 400  # minimum distance from star systems and black holes
+# Minimum distance allowed between the two wormholes in a pair
+WORMHOLE_PAIR_MIN_DISTANCE = 1200
 WORMHOLE_RADIUS = 20         # visible size of a worm hole
 WORMHOLE_COLOR = (150, 100, 200)
 WORMHOLE_DELAY = 5.0         # seconds before teleport occurs

--- a/src/sector.py
+++ b/src/sector.py
@@ -81,7 +81,7 @@ class Sector:
                 if math.hypot(hole.x - wx, hole.y - wy) < config.WORMHOLE_MIN_DISTANCE:
                     too_close = True
                     break
-            if math.hypot(first.x - wx, first.y - wy) < config.WORMHOLE_MIN_DISTANCE:
+            if math.hypot(first.x - wx, first.y - wy) < config.WORMHOLE_PAIR_MIN_DISTANCE:
                 too_close = True
             if not too_close:
                 second = WormHole(wx, wy)


### PR DESCRIPTION
## Summary
- document wormhole pair separation distance
- add `WORMHOLE_PAIR_MIN_DISTANCE` to config
- ensure paired wormholes spawn far apart

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68660301e9b08331b8e7fad9a80b77a6