### PR TITLE
Add dust clouds with abandoned stations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Wormholes now appear at least once in every generated universe, allowing
 instant travel between two distant points. The two ends of a pair are
 placed far apart thanks to the `WORMHOLE_PAIR_MIN_DISTANCE` setting.
 
+Dust clouds can also form within sectors. These large hazy areas dim any
+objects behind them and each has a 15% chance of concealing an abandoned
+station in its midst.
+
 ### Enemy AI
 
 A new `Enemy` class lives in `src/enemy.py`. It creates autonomous pilots

--- a/src/config.py
+++ b/src/config.py
@@ -71,3 +71,9 @@ ENEMY_WEAPON_COOLDOWN = 0.3
 # How often enemies attempt an orbit attack
 ENEMY_ORBIT_INTERVAL = 12.0  # seconds between orbit attempts
 ENEMY_ORBIT_PROBABILITY = 0.35  # chance of starting an orbit each interval
+
+# Dust cloud settings
+DUST_CLOUD_MIN_RADIUS = 200
+DUST_CLOUD_MAX_RADIUS = 400
+DUST_CLOUD_COLOR = (80, 70, 70)
+ABANDONED_STATION_CHANCE = 0.15

--- a/src/dust_cloud.py
+++ b/src/dust_cloud.py
@@ -1,0 +1,62 @@
+import pygame
+import random
+import math
+from station import SpaceStation
+import config
+
+
+class AbandonedStation(SpaceStation):
+    """Space station variant found drifting inside dust clouds."""
+
+    def draw(self, screen: pygame.Surface, offset_x: float = 0,
+             offset_y: float = 0, zoom: float = 1.0) -> None:
+        scaled_radius = max(1, int(self.radius * zoom))
+        pygame.draw.circle(
+            screen,
+            (120, 120, 150),
+            (int((self.x - offset_x) * zoom), int((self.y - offset_y) * zoom)),
+            scaled_radius,
+        )
+
+
+class DustCloud:
+    """Large cloudy region that hinders visibility."""
+
+    def __init__(self, x: float, y: float, radius: int,
+                 station: AbandonedStation | None = None) -> None:
+        self.x = x
+        self.y = y
+        self.radius = radius
+        self.station = station
+
+    @staticmethod
+    def random_cloud(xmin: int, xmax: int, ymin: int, ymax: int) -> "DustCloud":
+        x = random.randint(xmin, xmax)
+        y = random.randint(ymin, ymax)
+        radius = random.randint(
+            config.DUST_CLOUD_MIN_RADIUS, config.DUST_CLOUD_MAX_RADIUS
+        )
+        station = None
+        if random.random() < config.ABANDONED_STATION_CHANCE:
+            angle = random.uniform(0, 2 * math.pi)
+            dist = random.randint(0, radius // 2)
+            sx = x + int(math.cos(angle) * dist)
+            sy = y + int(math.sin(angle) * dist)
+            station = AbandonedStation(sx, sy)
+        return DustCloud(x, y, radius, station)
+
+    def draw(self, screen: pygame.Surface, offset_x: float = 0,
+             offset_y: float = 0, zoom: float = 1.0) -> None:
+        if self.station:
+            self.station.draw(screen, offset_x, offset_y, zoom)
+        scaled_radius = max(1, int(self.radius * zoom))
+        surf = pygame.Surface((scaled_radius * 2, scaled_radius * 2), pygame.SRCALPHA)
+        color = (*config.DUST_CLOUD_COLOR, 100)
+        pygame.draw.circle(surf, color, (scaled_radius, scaled_radius), scaled_radius)
+        screen.blit(
+            surf,
+            (
+                int((self.x - offset_x) * zoom) - scaled_radius,
+                int((self.y - offset_y) * zoom) - scaled_radius,
+            ),
+        )

--- a/src/main.py
+++ b/src/main.py
@@ -210,14 +210,24 @@ def main():
         near_station = None
         if not current_station:
             for sector in sectors:
+                found = False
                 for system in sector.systems:
                     for station in system.stations:
                         if math.hypot(station.x - ship.x, station.y - ship.y) < station.radius + 40:
                             near_station = station
+                            found = True
                             break
-                    if near_station:
+                    if found:
                         break
-                if near_station:
+                if found:
+                    break
+                for cloud in sector.dust_clouds:
+                    st = cloud.station
+                    if st and math.hypot(st.x - ship.x, st.y - ship.y) < st.radius + 40:
+                        near_station = st
+                        found = True
+                        break
+                if found:
                     break
         cancel_rect = pygame.Rect(
             config.WINDOW_WIDTH // 2 - 70, config.WINDOW_HEIGHT - 40, 20, 20

--- a/src/sector.py
+++ b/src/sector.py
@@ -4,6 +4,7 @@ import pygame
 from star_system import StarSystem
 from blackhole import BlackHole
 from wormhole import WormHole
+from dust_cloud import DustCloud
 import config
 
 class Sector:
@@ -48,6 +49,17 @@ class Sector:
         self.wormholes = []
         if random.random() < config.WORMHOLE_CHANCE:
             self._add_wormhole_pair()
+
+        # Add a few dust clouds that may hide abandoned stations
+        self.dust_clouds = []
+        for _ in range(random.randint(0, 2)):
+            cloud = DustCloud.random_cloud(
+                self.x + 100,
+                self.x + self.width - 100,
+                self.y + 100,
+                self.y + self.height - 100,
+            )
+            self.dust_clouds.append(cloud)
 
     def _add_wormhole_pair(self) -> None:
         """Generate and store a paired set of wormholes in this sector."""
@@ -106,6 +118,8 @@ class Sector:
             hole.draw(screen, offset_x, offset_y, zoom)
         for hole in self.wormholes:
             hole.draw(screen, offset_x, offset_y, zoom)
+        for cloud in self.dust_clouds:
+            cloud.draw(screen, offset_x, offset_y, zoom)
 
     def collides_with_point(self, x: float, y: float, radius: float) -> bool:
         if not (self.x <= x <= self.x + self.width and self.y <= y <= self.y + self.height):
@@ -126,6 +140,9 @@ class Sector:
             obj = system.get_object_at_point(x, y, radius)
             if obj:
                 return obj
+        for cloud in self.dust_clouds:
+            if cloud.station and math.hypot(cloud.station.x - x, cloud.station.y - y) < cloud.station.radius + radius:
+                return cloud.station
         return None
 
 


### PR DESCRIPTION
## Summary
- introduce `DustCloud` and `AbandonedStation` entities
- generate dust clouds in each sector
- allow 15% chance for a derelict station in a cloud
- show dust cloud settings in config
- update station detection logic
- document new feature in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686607accbd88331a241f77cd48a733e