### PR TITLE
Add Gravity Tractor artifact and clearer ability slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,9 @@ is a short cooldown before it can be triggered again.
 Projectiles now vanish after travelling around 1200 pixels. Shots fired while
 orbiting curve sharply towards the target so they rarely miss. Normal shots
 travel in a straight line.
+
+### Artifacts
+Ships can equip artifacts that provide situational abilities. Along with the EMP
+and Area Shield, a new **Gravity Tractor** generates a miniature black hole that
+weakly pulls nearby ships for 15 seconds. It has a 30&nbsp;second cooldown before
+it can be deployed again.

--- a/src/artifact.py
+++ b/src/artifact.py
@@ -81,3 +81,19 @@ class AreaShieldArtifact(Artifact):
         user.area_shield = AreaShieldAura(user)
         user.specials.append(user.area_shield)
 
+
+class GravityTractorArtifact(Artifact):
+    """Spawn a small gravity well that tugs nearby ships."""
+
+    def __init__(self) -> None:
+        super().__init__("Gravity Tractor", cooldown=30.0)
+
+    def activate(self, user, enemies: list) -> None:
+        if not self.can_use():
+            return
+        from blackhole import TemporaryBlackHole
+
+        self._timer = 0.0
+        hole = TemporaryBlackHole(user.x, user.y)
+        user.specials.append(hole)
+

--- a/src/blackhole.py
+++ b/src/blackhole.py
@@ -43,3 +43,25 @@ class BlackHole:
             ship.vx += dx / dist * pull * dt
             ship.vy += dy / dist * pull * dt
 
+
+class TemporaryBlackHole(BlackHole):
+    """A short-lived version of ``BlackHole`` used by artifacts."""
+
+    def __init__(
+        self,
+        x: float,
+        y: float,
+        radius: int = 15,
+        pull_range: int = 220,
+        strength: float = 15000.0,
+        lifetime: float = 15.0,
+    ) -> None:
+        super().__init__(x, y, radius, pull_range, strength)
+        self.lifetime = lifetime
+
+    def update(self, dt: float) -> None:
+        self.lifetime -= dt
+
+    def expired(self) -> bool:
+        return self.lifetime <= 0
+

--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,7 @@ from star import Star
 from planet import Planet
 from station import SpaceStation
 from ui import DropdownMenu, RoutePlanner, InventoryWindow, AbilityBar, WeaponMenu, ArtifactMenu
-from artifact import EMPArtifact, AreaShieldArtifact
+from artifact import EMPArtifact, AreaShieldArtifact, GravityTractorArtifact
 from planet_surface import PlanetSurface
 from character import create_player
 
@@ -105,7 +105,7 @@ def main():
     ])
     for w in ship.weapons:
         w.owner = ship
-    ship.artifacts = [EMPArtifact(), AreaShieldArtifact()]
+    ship.artifacts = [EMPArtifact(), AreaShieldArtifact(), GravityTractorArtifact()]
 
     zoom = 1.0
     selected_object = None

--- a/src/ship.py
+++ b/src/ship.py
@@ -15,6 +15,7 @@ from combat import (
     MissileWeapon,
 )
 from artifact import Artifact, EMPArtifact, AreaShieldArtifact, AreaShieldAura
+from blackhole import TemporaryBlackHole
 
 
 @dataclass
@@ -452,6 +453,13 @@ class Ship:
                     for en in enemies:
                         if math.hypot(en.ship.x - obj.x, en.ship.y - obj.y) <= obj.radius:
                             en.ship.take_damage(obj.damage)
+                if obj.expired():
+                    self.specials.remove(obj)
+            elif isinstance(obj, TemporaryBlackHole):
+                obj.update(dt)
+                obj.apply_pull(self, dt)
+                for en in enemies or []:
+                    obj.apply_pull(en.ship, dt)
                 if obj.expired():
                     self.specials.remove(obj)
             elif isinstance(obj, AreaShieldAura):

--- a/src/ui.py
+++ b/src/ui.py
@@ -244,8 +244,8 @@ class AbilityBar:
     """Display up to five ability slots at the bottom of the screen."""
 
     SLOT_COUNT = 5
-    SLOT_W = 60
-    SLOT_H = 30
+    SLOT_W = 80
+    SLOT_H = 40
     MARGIN = 5
 
     def __init__(self) -> None:
@@ -312,7 +312,10 @@ class AbilityBar:
             pygame.draw.rect(screen, (200, 200, 200), rect, 1)
             name, key = self.slots[i]
             if name:
-                txt = font.render(f"{name} ({key})", True, (255, 255, 255))
-                txt_rect = txt.get_rect(center=rect.center)
+                txt = font.render(name, True, (255, 255, 255))
+                txt_rect = txt.get_rect(center=(rect.centerx, rect.centery - 8))
                 screen.blit(txt, txt_rect)
+            key_txt = font.render(key, True, (255, 255, 255))
+            key_rect = key_txt.get_rect(bottomright=(rect.right - 4, rect.bottom - 2))
+            screen.blit(key_txt, key_rect)
 


### PR DESCRIPTION
## Summary
- introduce `TemporaryBlackHole` and `GravityTractorArtifact`
- pull new artifact into starting loadout
- support temporary black hole behaviour in `Ship`
- make ability bar slots bigger and display key separately
- document new artifact in README

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686726297bbc8331a478704814790682