### PR TITLE
Enable click placement for Gravity Tractor artifact

### DIFF
--- a/src/artifact.py
+++ b/src/artifact.py
@@ -87,13 +87,25 @@ class GravityTractorArtifact(Artifact):
 
     def __init__(self) -> None:
         super().__init__("Gravity Tractor", cooldown=30.0)
+        self.awaiting_click: bool = False
+        self._pending_user = None
 
     def activate(self, user, enemies: list) -> None:
-        if not self.can_use():
+        if not self.can_use() or self.awaiting_click:
+            return
+        # Activation now waits for the player to choose a point.
+        self.awaiting_click = True
+        self._pending_user = user
+
+    def confirm(self, x: float, y: float) -> None:
+        """Place the tractor at ``(x, y)`` once the target is chosen."""
+        if not self.awaiting_click or not self._pending_user:
             return
         from blackhole import TemporaryBlackHole
 
         self._timer = 0.0
-        hole = TemporaryBlackHole(user.x, user.y)
-        user.specials.append(hole)
+        hole = TemporaryBlackHole(x, y)
+        self._pending_user.specials.append(hole)
+        self.awaiting_click = False
+        self._pending_user = None
 


### PR DESCRIPTION
## Summary
- add targeting mode to `GravityTractorArtifact`
- allow selecting placement by mouse click in main loop
- show message overlay when tractor is awaiting placement

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686727fb498c8331babd7965799a9f31