### PR TITLE
Add purple particles and boost gravity

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ placed far apart thanks to the `WORMHOLE_PAIR_MIN_DISTANCE` setting.
 ### Black holes
 The ominous singularities exert their pull from farther away. Normal black
 holes now affect ships within a 25% larger radius and feature a swirling
-purple halo to emphasize their danger.
+purple halo to emphasize their danger. Dark purple particles now orbit
+throughout the entire pull range, and the gravitational force is 20% stronger.
 
 ### Enemy AI
 

--- a/src/artifact.py
+++ b/src/artifact.py
@@ -137,7 +137,8 @@ class TractorProbe:
         if self.timer >= self.duration and not self.deployed:
             from blackhole import TemporaryBlackHole
 
-            strength = 15000.0 * 1.25
+            # 20% stronger gravitational pull
+            strength = 15000.0 * 1.25 * 1.2
             lifetime = 15.0 + 15.0
             hole = TemporaryBlackHole(
                 self.target_x, self.target_y, strength=strength, lifetime=lifetime

--- a/src/blackhole.py
+++ b/src/blackhole.py
@@ -9,9 +9,12 @@ class _Particle:
 
     def __init__(self, hole: "BlackHole") -> None:
         self.angle = random.uniform(0, math.tau)
-        self.radius = random.uniform(hole.radius + 10, hole.radius + 40)
+        # Particles now span the full gravitational range for a wider swirl
+        self.radius = random.uniform(hole.radius, hole.pull_range)
         self.speed = random.uniform(0.5, 1.2)
         self.size = random.randint(1, 3)
+        # Dark purple hue for a more ominous effect
+        self.color = (80, 0, 80)
         self.lifetime = random.uniform(4.0, 8.0)
 
     def update(self, dt: float) -> None:
@@ -72,11 +75,11 @@ class BlackHole:
             pygame.draw.circle(halo, color, (halo_radius, halo_radius), halo_radius, 2)
             screen.blit(halo, (center[0] - halo_radius, center[1] - halo_radius))
 
-        # Draw orbiting particles
+        # Draw orbiting particles in a dark purple hue
         for p in self.particles:
             px = center[0] + int(math.cos(p.angle) * p.radius * zoom)
             py = center[1] + int(math.sin(p.angle) * p.radius * zoom)
-            pygame.draw.circle(screen, (200, 200, 255), (px, py), max(1, int(p.size * zoom)))
+            pygame.draw.circle(screen, p.color, (px, py), max(1, int(p.size * zoom)))
 
         pygame.draw.circle(screen, (80, 0, 80), center, scaled_radius, 1)
 
@@ -105,7 +108,7 @@ class TemporaryBlackHole(BlackHole):
         y: float,
         radius: int = 15,
         pull_range: int = 253,  # 15% larger pull range for artifact holes
-        strength: float = 15000.0,
+        strength: float = 18000.0,  # 20% stronger gravitational pull
         lifetime: float = 15.0,
     ) -> None:
         super().__init__(x, y, radius, pull_range, strength)

--- a/src/config.py
+++ b/src/config.py
@@ -46,7 +46,7 @@ BLACKHOLE_CHANCE = 0.15       # probability of a sector containing a black hole
 BLACKHOLE_MIN_DISTANCE = 600  # minimum distance from any star system
 # distance at which the ship feels the pull
 BLACKHOLE_RANGE = 375         # increased by 25% for a stronger presence
-BLACKHOLE_STRENGTH = 40000    # acceleration force applied when near
+BLACKHOLE_STRENGTH = 48000    # acceleration force applied when near (20% stronger)
 BLACKHOLE_RADIUS = 25         # radius of the dangerous core
 BLACKHOLE_FLASH_TIME = 1.0    # duration of whiteout when swallowed
 


### PR DESCRIPTION
## Summary
- enhance black hole visuals with dark purple particles that swirl across the entire pull range
- increase black hole gravitational force by 20%
- update artifact temporary holes to match stronger gravity
- document new effects in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6867320783f88331a963a33c228bffaf