### PR TITLE
Add repair bots, solar link and decoy artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,14 @@ the selected point. After five seconds the probe deploys a miniature black hole
 that tugs nearby ships 25% harder, covers a 15% wider radius and lasts
 30&nbsp;seconds. This ability has a 35&nbsp;second cooldown before it can be
 deployed again.
+
+Three additional artifacts expand your tactical options:
+
+* **Repair Bots** – releases nanobots that restore hull and shields over five
+  seconds. This ability has a 15&nbsp;second cooldown.
+* **Solar Link** – connects the ship to the nearest star within 500 pixels,
+  boosting shield recharge and weapon rates for six seconds. It cannot be used
+  if no star is close. Cooldown: 20&nbsp;seconds.
+* **Decoy** – projects a fragile copy of the ship that lasts a few seconds or
+  until destroyed. Activating it cloaks your ship for three seconds. Cooldown:
+  18&nbsp;seconds.


### PR DESCRIPTION
## Summary
- implement `NanobotArtifact`, `SolarGeneratorArtifact` and `DecoyArtifact`
- add supporting effect classes (`RepairNanobots`, `SolarLink`, `Decoy`)
- extend `Ship` with `max_hull`, `invisible_timer` and sector storage
- update ability logic to handle new effects
- document the new artifacts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6867334f9d2c83318ad8e06523e6f52e