### PR TITLE
Add artifact selection UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,7 @@ Three additional artifacts expand your tactical options:
 * **Decoy** – projects a fragile copy of the ship that lasts a few seconds or
   until destroyed. Activating it cloaks your ship for three seconds. Cooldown:
   18&nbsp;seconds.
+
+Press **G** to open the artifact menu. All available artifacts are listed and
+clicking one lets you choose the ability slot by pressing **1**, **2** or **3**.
+The first two slots (Boost and Orbit) cannot be replaced.

--- a/src/artifact.py
+++ b/src/artifact.py
@@ -337,3 +337,16 @@ class DecoyArtifact(Artifact):
         user.specials.append(Decoy(user))
         user.invisible_timer = 3.0
 
+
+# Registry of all artifact types available in the game. This is used by the
+# UI to display every artifact even if the player's ship has not equipped it
+# yet.
+AVAILABLE_ARTIFACTS: list[type[Artifact]] = [
+    EMPArtifact,
+    AreaShieldArtifact,
+    GravityTractorArtifact,
+    NanobotArtifact,
+    SolarGeneratorArtifact,
+    DecoyArtifact,
+]
+

--- a/src/main.py
+++ b/src/main.py
@@ -167,10 +167,7 @@ def main():
                     weapon_menu = WeaponMenu(ship)
                     continue
                 if event.type == pygame.KEYDOWN and event.key == pygame.K_g:
-                    artifact_menu = ArtifactMenu(ship)
-                    continue
-                if event.type == pygame.KEYDOWN and event.key == pygame.K_g:
-                    artifact_menu = ArtifactMenu(ship)
+                    artifact_menu = ArtifactMenu(ship, ability_bar)
                     continue
                 if (
                     event.type == pygame.MOUSEBUTTONDOWN
@@ -301,7 +298,7 @@ def main():
             elif selection == "Weapons":
                 weapon_menu = WeaponMenu(ship)
             elif selection == "Artifacts":
-                artifact_menu = ArtifactMenu(ship)
+                artifact_menu = ArtifactMenu(ship, ability_bar)
 
             route_planner.handle_event(event, sectors, (camera_x, camera_y), zoom)
             ability_bar.handle_event(event, ship, enemies)
@@ -350,7 +347,7 @@ def main():
                 elif event.key == pygame.K_f:
                     weapon_menu = WeaponMenu(ship)
                 elif event.key == pygame.K_g:
-                    artifact_menu = ArtifactMenu(ship)
+                    artifact_menu = ArtifactMenu(ship, ability_bar)
                 elif event.key == pygame.K_r:
                     nearest = None
                     min_dist = float("inf")


### PR DESCRIPTION
## Summary
- add list of available artifacts to `artifact.py`
- overhaul `ArtifactMenu` to allow equipping artifacts by pressing keys 1-3
- display the current ability bar in the artifact menu
- pass ability bar into the menu in `main.py`
- document artifact menu usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: many style violations)*

------
https://chatgpt.com/codex/tasks/task_e_68673760e2ec8331aacc485d0cbe9a50