### PR TITLE
Enable enemy factions and ally handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ button to return to space.
 When starting the game you can personalise the player by entering a name,
 age, species and a **fraction** (faction). Five fictional fractions are
 available, each with a short description and a small boost for its members.
+Enemies are also assigned one of these fractions when spawned. Those sharing
+your fraction behave as allies while the rest remain hostile.
 After the character is created you can also choose a starting ship from a
 small catalogue of models, each with its own brand and classification.
 

--- a/src/main.py
+++ b/src/main.py
@@ -416,9 +416,18 @@ def main():
             continue
 
         keys = pygame.key.get_pressed()
-        ship.update(keys, dt, world_width, world_height, sectors, blackholes, enemies)
+        hostiles = [en for en in enemies if en.fraction != player.fraction]
+        ship.update(keys, dt, world_width, world_height, sectors, blackholes, hostiles)
         for enemy in list(enemies):
-            enemy.update(ship, dt, world_width, world_height, sectors, blackholes)
+            enemy.update(
+                ship,
+                dt,
+                world_width,
+                world_height,
+                sectors,
+                blackholes,
+                player.fraction,
+            )
 
             enemy_rect = pygame.Rect(
                 enemy.ship.x - enemy.ship.size / 2,
@@ -433,15 +442,16 @@ def main():
                 ship.size,
             )
 
-            for proj in list(ship.projectiles):
-                if enemy_rect.collidepoint(proj.x, proj.y):
-                    enemy.ship.take_damage(proj.damage)
-                    ship.projectiles.remove(proj)
+            if enemy.fraction != player.fraction:
+                for proj in list(ship.projectiles):
+                    if enemy_rect.collidepoint(proj.x, proj.y):
+                        enemy.ship.take_damage(proj.damage)
+                        ship.projectiles.remove(proj)
 
-            for proj in list(enemy.ship.projectiles):
-                if ship_rect.collidepoint(proj.x, proj.y):
-                    ship.take_damage(proj.damage)
-                    enemy.ship.projectiles.remove(proj)
+                for proj in list(enemy.ship.projectiles):
+                    if ship_rect.collidepoint(proj.x, proj.y):
+                        ship.take_damage(proj.damage)
+                        enemy.ship.projectiles.remove(proj)
 
             if enemy.ship.hull <= 0:
                 enemies.remove(enemy)


### PR DESCRIPTION
## Summary
- add factions to `Enemy` and `LearningEnemy`
- spawn enemies with a random faction
- skip hostile behaviour when an enemy shares the player's faction
- filter allied ships from missile targeting and collision checks
- document factions affecting enemies

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68673d5790748331b2b618b1a8eb6ba6