### PR TITLE
Add savegame support and profile selection

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -13,7 +13,7 @@ from station import SpaceStation
 from ui import DropdownMenu, RoutePlanner, InventoryWindow, AbilityBar, WeaponMenu, ArtifactMenu
 from artifact import EMPArtifact, AreaShieldArtifact, GravityTractorArtifact
 from planet_surface import PlanetSurface
-from character import create_player
+from character import choose_player
 
 
 def draw_station_ui(screen: pygame.Surface, station: SpaceStation, font: pygame.font.Font) -> tuple[pygame.Rect, pygame.Rect]:
@@ -69,7 +69,7 @@ def main():
     screen = pygame.display.set_mode((config.WINDOW_WIDTH, config.WINDOW_HEIGHT))
     pygame.display.set_caption("VastVoid")
 
-    player = create_player(screen)
+    player = choose_player(screen)
 
     sectors = create_sectors(
         config.GRID_SIZE, config.SECTOR_WIDTH, config.SECTOR_HEIGHT

--- a/src/savegame.py
+++ b/src/savegame.py
@@ -1,0 +1,88 @@
+import json
+import os
+from typing import List
+
+from character import Player, Human, Alien, Robot
+from fraction import FRACTIONS
+from items import ITEM_NAMES
+from ship import SHIP_MODELS, ShipModel
+
+SAVE_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "saves")
+
+
+def _model_to_dict(model: ShipModel | None):
+    if not model:
+        return None
+    return {
+        "classification": model.classification,
+        "brand": model.brand,
+    }
+
+
+def _dict_to_model(data: dict | None) -> ShipModel | None:
+    if not data:
+        return None
+    classification = data.get("classification")
+    brand = data.get("brand")
+    for m in SHIP_MODELS:
+        if m.classification == classification and m.brand == brand:
+            return m
+    return None
+
+
+def save_player(player: Player) -> None:
+    """Serialize Player data to JSON inside the saves directory."""
+    os.makedirs(SAVE_DIR, exist_ok=True)
+    path = os.path.join(SAVE_DIR, f"{player.name}.json")
+    data = {
+        "name": player.name,
+        "age": player.age,
+        "species": player.species.species,
+        "fraction": player.fraction.name,
+        "inventory": player.inventory,
+        "credits": player.credits,
+        "ship_model": _model_to_dict(player.ship_model),
+    }
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def load_player(name: str) -> Player:
+    """Read JSON data and reconstruct a Player instance."""
+    path = os.path.join(SAVE_DIR, f"{name}.json")
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    species_map = {"Human": Human, "Alien": Alien, "Robot": Robot}
+    species_cls = species_map.get(data.get("species"), Human)
+    species = species_cls()
+    fraction = next((f for f in FRACTIONS if f.name == data.get("fraction")), FRACTIONS[0])
+    player = Player(
+        data.get("name", name),
+        int(data.get("age", 0)),
+        species,
+        fraction,
+        ship_model=_dict_to_model(data.get("ship_model")),
+        credits=int(data.get("credits", 0)),
+    )
+    inv = {item: 0 for item in ITEM_NAMES}
+    inv.update(data.get("inventory", {}))
+    player.inventory = inv
+    return player
+
+
+def list_players() -> List[str]:
+    """Return the list of saved player profile names."""
+    if not os.path.isdir(SAVE_DIR):
+        return []
+    names = []
+    for fname in os.listdir(SAVE_DIR):
+        if fname.endswith(".json"):
+            names.append(os.path.splitext(fname)[0])
+    return sorted(names)
+
+
+def delete_player(name: str) -> None:
+    """Delete the save file for the given player name."""
+    path = os.path.join(SAVE_DIR, f"{name}.json")
+    if os.path.exists(path):
+        os.remove(path)


### PR DESCRIPTION
## Summary
- extend `Player` with a `credits` attribute
- create a `savegame` module for saving and loading player profiles
- offer a `choose_player` menu to load or remove profiles or create new ones
- call `choose_player` at startup instead of always creating a new player

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867450d446c8331ab2dca0bb1d96a31