### PR TITLE
Add item lookup helper

### DIFF
--- a/src/character.py
+++ b/src/character.py
@@ -1,7 +1,7 @@
 import pygame
 import config
 from fraction import FRACTIONS, Fraction
-from items import ITEM_NAMES
+from items import ITEMS_BY_NAME
 
 class Alien:
     """Basic Alien species."""
@@ -37,7 +37,7 @@ class Player:
         self.ship_model = ship_model
         self.credits = credits
         # Inventory starts empty but contains an entry for each known item
-        self.inventory: dict[str, int] = {item: 0 for item in ITEM_NAMES}
+        self.inventory: dict[str, int] = {name: 0 for name in ITEMS_BY_NAME}
 
     def add_item(self, item: str, quantity: int = 1) -> None:
         """Add `quantity` of `item` to the inventory."""

--- a/src/items.py
+++ b/src/items.py
@@ -259,5 +259,13 @@ ITEMS_BY_TYPE: Dict[str, List[Item]] = {
 # Flatten list with all items
 ITEMS: List[Item] = [item for group in ITEMS_BY_TYPE.values() for item in group]
 
+# Fast lookup table by item name
+ITEMS_BY_NAME: Dict[str, Item] = {item.nombre: item for item in ITEMS}
+
+
+def get_item(name: str) -> Item:
+    """Return the :class:`Item` matching ``name``."""
+    return ITEMS_BY_NAME[name]
+
 # List of item names for backwards compatibility
-ITEM_NAMES: List[str] = [item.nombre for item in ITEMS]
+ITEM_NAMES: List[str] = list(ITEMS_BY_NAME.keys())

--- a/src/planet_surface.py
+++ b/src/planet_surface.py
@@ -3,7 +3,7 @@ import pygame
 import random
 import config
 from biome import BIOMES, Biome
-from items import ITEM_NAMES
+
 
 
 ENV_COLORS = {

--- a/src/savegame.py
+++ b/src/savegame.py
@@ -4,7 +4,7 @@ from typing import List
 
 from character import Player, Human, Alien, Robot
 from fraction import FRACTIONS
-from items import ITEM_NAMES
+from items import ITEMS_BY_NAME
 from ship import SHIP_MODELS, ShipModel
 
 SAVE_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "saves")
@@ -64,7 +64,7 @@ def load_player(name: str) -> Player:
         ship_model=_dict_to_model(data.get("ship_model")),
         credits=int(data.get("credits", 0)),
     )
-    inv = {item: 0 for item in ITEM_NAMES}
+    inv = {name: 0 for name in ITEMS_BY_NAME}
     inv.update(data.get("inventory", {}))
     player.inventory = inv
     return player


### PR DESCRIPTION
## Summary
- create `ITEMS_BY_NAME` dict for quick lookup
- expose `get_item` helper
- adjust character and savegame modules to use new dictionary
- drop unused import in planet_surface

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6867463863c08331a010453a9d4cb11b