### PR TITLE
Add profile selection table UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ your fraction behave as allies while the rest remain hostile.
 After the character is created you can also choose a starting ship from a
 small catalogue of models, each with its own brand and classification.
 
+Saved profiles are presented in a simple table when the game launches.
+Each row lists the player's name alongside **Load** and **Delete** buttons,
+and a separate *New Profile* button lets you create a fresh character.
+
 ## Running the game
 
 ```bash

--- a/src/character.py
+++ b/src/character.py
@@ -177,3 +177,69 @@ def choose_player(screen: pygame.Surface) -> Player:
             screen.blit(msg, (50, 100 + i * 30))
         pygame.display.flip()
         clock.tick(30)
+
+
+def choose_player_table(screen: pygame.Surface) -> Player:
+    """GUI with buttons to load or delete a profile."""
+    from savegame import list_players, load_player, delete_player
+
+    font = pygame.font.Font(None, 32)
+    clock = pygame.time.Clock()
+    name_w, btn_w, row_h = 200, 100, 40
+    spacing = 10
+    start_x, start_y = 50, 100
+
+    while True:
+        profiles = list_players()
+        row_rects: list[tuple[pygame.Rect, pygame.Rect]] = []
+        y = start_y
+        for _ in profiles:
+            load_rect = pygame.Rect(start_x + name_w + spacing, y, btn_w, row_h)
+            del_rect = pygame.Rect(
+                start_x + name_w + spacing * 2 + btn_w, y, btn_w, row_h
+            )
+            row_rects.append((load_rect, del_rect))
+            y += row_h + 5
+        new_rect = pygame.Rect(start_x, y + 20, btn_w * 2, row_h)
+
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                raise SystemExit
+            if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+                for idx, (load_rect, del_rect) in enumerate(row_rects):
+                    if load_rect.collidepoint(event.pos):
+                        return load_player(profiles[idx])
+                    if del_rect.collidepoint(event.pos):
+                        delete_player(profiles[idx])
+                if new_rect.collidepoint(event.pos):
+                    return create_player(screen)
+
+        screen.fill(config.BACKGROUND_COLOR)
+        y = start_y
+        for i, name in enumerate(profiles):
+            name_rect = pygame.Rect(start_x, y, name_w, row_h)
+            pygame.draw.rect(screen, (60, 60, 90), name_rect)
+            pygame.draw.rect(screen, (200, 200, 200), name_rect, 1)
+            txt = font.render(name, True, (255, 255, 255))
+            screen.blit(txt, txt.get_rect(center=name_rect.center))
+
+            load_rect, del_rect = row_rects[i]
+            pygame.draw.rect(screen, (60, 60, 90), load_rect)
+            pygame.draw.rect(screen, (200, 200, 200), load_rect, 1)
+            load_txt = font.render("Load", True, (255, 255, 255))
+            screen.blit(load_txt, load_txt.get_rect(center=load_rect.center))
+
+            pygame.draw.rect(screen, (60, 60, 90), del_rect)
+            pygame.draw.rect(screen, (200, 200, 200), del_rect, 1)
+            del_txt = font.render("Delete", True, (255, 255, 255))
+            screen.blit(del_txt, del_txt.get_rect(center=del_rect.center))
+            y += row_h + 5
+
+        pygame.draw.rect(screen, (60, 60, 90), new_rect)
+        pygame.draw.rect(screen, (200, 200, 200), new_rect, 1)
+        new_txt = font.render("New Profile", True, (255, 255, 255))
+        screen.blit(new_txt, new_txt.get_rect(center=new_rect.center))
+
+        pygame.display.flip()
+        clock.tick(30)

--- a/src/main.py
+++ b/src/main.py
@@ -21,7 +21,7 @@ from ui import (
 )
 from artifact import EMPArtifact, AreaShieldArtifact, GravityTractorArtifact
 from planet_surface import PlanetSurface
-from character import choose_player
+from character import choose_player_table
 
 
 def draw_station_ui(
@@ -90,7 +90,7 @@ def main():
     screen = pygame.display.set_mode((config.WINDOW_WIDTH, config.WINDOW_HEIGHT))
     pygame.display.set_caption("VastVoid")
 
-    player = choose_player(screen)
+    player = choose_player_table(screen)
 
     sectors = create_sectors(
         config.GRID_SIZE, config.SECTOR_WIDTH, config.SECTOR_HEIGHT


### PR DESCRIPTION
## Summary
- add GUI for profile management with Load/Delete buttons
- call the new `choose_player_table` from `main.py`
- document profile table in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6868397809a0833185241238462f19d5