### PR TITLE
Fix profile saving on creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ small catalogue of models, each with its own brand and classification.
 Saved profiles are presented in a simple table when the game launches.
 Each row lists the player's name alongside **Load** and **Delete** buttons,
 and a separate *New Profile* button lets you create a fresh character.
+New profiles are saved automatically once created so they appear on the list
+the next time you run the game.
 
 ## Running the game
 

--- a/src/character.py
+++ b/src/character.py
@@ -137,7 +137,7 @@ def create_player(screen: pygame.Surface) -> Player:
 
 def choose_player(screen: pygame.Surface) -> Player:
     """Let the user pick an existing profile or create/delete one."""
-    from savegame import list_players, load_player, delete_player
+    from savegame import list_players, load_player, delete_player, save_player
 
     font = pygame.font.Font(None, 32)
     clock = pygame.time.Clock()
@@ -160,6 +160,7 @@ def choose_player(screen: pygame.Surface) -> Player:
                         return load_player(profiles[idx])
                 elif event.unicode.lower() == "n":
                     player = create_player(screen)
+                    save_player(player)
                     return player
                 elif event.unicode.lower() == "d":
                     deleting = True
@@ -181,7 +182,7 @@ def choose_player(screen: pygame.Surface) -> Player:
 
 def choose_player_table(screen: pygame.Surface) -> Player:
     """GUI with buttons to load or delete a profile."""
-    from savegame import list_players, load_player, delete_player
+    from savegame import list_players, load_player, delete_player, save_player
 
     font = pygame.font.Font(None, 32)
     clock = pygame.time.Clock()
@@ -213,7 +214,9 @@ def choose_player_table(screen: pygame.Surface) -> Player:
                     if del_rect.collidepoint(event.pos):
                         delete_player(profiles[idx])
                 if new_rect.collidepoint(event.pos):
-                    return create_player(screen)
+                    player = create_player(screen)
+                    save_player(player)
+                    return player
 
         screen.fill(config.BACKGROUND_COLOR)
         y = start_y


### PR DESCRIPTION
## Summary
- save new profiles when they are created so Load/Delete buttons appear
- document auto-saving of new profiles

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68683e2fb8f88331a92e8c3cd2e08b55