### PR TITLE
Add visual traits to faction structures

### DIFF
--- a/src/faction_structures.py
+++ b/src/faction_structures.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass, field
 from typing import Any
 
-from fraction import Fraction
+from fraction import Fraction, Color
 
 
 @dataclass
@@ -13,6 +13,9 @@ class FactionStructure:
     name: str
     fraction: Fraction | None = None
     modules: list[str] = field(default_factory=list)
+    color: Color | None = None
+    shape: str | None = None
+    aura: str | None = None
 
     def apply_fraction_traits(self, fraction: Fraction) -> None:
         """Configure this structure with properties for ``fraction``.
@@ -21,6 +24,9 @@ class FactionStructure:
         modifications like additional modules or stat bonuses.
         """
         self.fraction = fraction
+        self.color = fraction.color
+        self.shape = fraction.shape
+        self.aura = fraction.aura
 
 
 @dataclass

--- a/src/fraction.py
+++ b/src/fraction.py
@@ -1,11 +1,16 @@
 from dataclasses import dataclass
 
+Color = tuple[int, int, int]
+
 @dataclass
 class Fraction:
     """Represents a faction players can belong to."""
     name: str
     description: str
     boost: str
+    color: Color
+    shape: str
+    aura: str
 
 # Predefined fractions with simple boosts
 FRACTIONS = [
@@ -13,25 +18,40 @@ FRACTIONS = [
         name="Solar Dominion",
         description="Militaristic regime focused on expanding its stellar influence.",
         boost="Increases ship speed slightly",
+        color=(255, 190, 70),
+        shape="angular",
+        aura="radiant",
     ),
     Fraction(
         name="Cosmic Guild",
         description="Alliance of traders and engineers controlling most commerce routes.",
         boost="Better prices at stations",
+        color=(50, 200, 255),
+        shape="round",
+        aura="trade",
     ),
     Fraction(
         name="Nebula Order",
         description="Scholars dedicated to studying anomalies and black holes.",
         boost="Sensors reveal planets from farther away",
+        color=(180, 70, 255),
+        shape="sleek",
+        aura="mystic",
     ),
     Fraction(
         name="Pirate Clans",
         description="Loose coalition of outlaws thriving on ambush and stealth.",
         boost="Autopilot evades hazards more efficiently",
+        color=(200, 50, 50),
+        shape="spiky",
+        aura="shadow",
     ),
     Fraction(
         name="Free Explorers",
         description="Independent pilots seeking new frontiers beyond charted space.",
         boost="Faster boost recharge",
+        color=(80, 255, 80),
+        shape="streamlined",
+        aura="adventure",
     ),
 ]


### PR DESCRIPTION
## Summary
- extend `Fraction` with visual fields (`color`, `shape`, `aura`)
- map each predefined faction to its style
- allow `FactionStructure` to store and apply those attributes

## Testing
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_68687a3deab88331a0a26a25f0322d04