### PR TITLE
Enable dragging HyperJump map with mouse press

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ is a short cooldown before it can be triggered again.
 A round **Hyper** button sits to the right of the slots. Clicking it opens a
 large map of the surrounding sectors. Left-click anywhere on the map to place a
 destination marker, then press **Confirm** to initiate a jump. Right-click and
-drag to pan the view. Hyperjumps occur after a brief one-second delay and you
+drag to pan the view, or hold the left button to drag while pressed. Hyperjumps occur after a brief one-second delay and you
 must wait eight seconds before jumping again.
 
 Projectiles now vanish after travelling around 1200 pixels. Shots fired while

--- a/src/ui.py
+++ b/src/ui.py
@@ -494,17 +494,19 @@ class HyperJumpMap:
                 wx = event.pos[0] / self.zoom + off_x
                 wy = event.pos[1] / self.zoom + off_y
                 self.destination = (wx, wy)
+                self.last_mouse = event.pos
             elif event.button == 3:
                 self.dragging = True
                 self.last_mouse = event.pos
         elif event.type == pygame.MOUSEBUTTONUP and event.button == 3:
             self.dragging = False
-        elif event.type == pygame.MOUSEMOTION and self.dragging:
-            dx = event.pos[0] - self.last_mouse[0]
-            dy = event.pos[1] - self.last_mouse[1]
-            self.camera_x -= dx / self.zoom
-            self.camera_y -= dy / self.zoom
-            self.last_mouse = event.pos
+        elif event.type == pygame.MOUSEMOTION:
+            if self.dragging or event.buttons[0]:
+                dx = event.pos[0] - self.last_mouse[0]
+                dy = event.pos[1] - self.last_mouse[1]
+                self.camera_x -= dx / self.zoom
+                self.camera_y -= dy / self.zoom
+                self.last_mouse = event.pos
         return False
 
     def draw(self, screen: pygame.Surface, font: pygame.font.Font) -> None:


### PR DESCRIPTION
## Summary
- allow camera drag while holding the left mouse button on the HyperJump map
- document that both mouse buttons can drag the map

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68688f04ff088331a32e282b1431f17a