### PR TITLE
Improve hyperjump timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ t(d) = d / v(d)
 
 where `v0` is 2.0 pc/s, `d0` is 0.5 pc and `k` is 3.
 
+Travel time is clamped between 1 and 60 seconds so even nearby jumps last at
+least a second while distant ones never exceed a minute. The vignette overlay is
+darker to emphasize the effect.
+
 Projectiles now vanish after travelling around 1200 pixels. Shots fired while
 orbiting curve sharply towards the target so they rarely miss. Normal shots
 travel in a straight line.

--- a/src/config.py
+++ b/src/config.py
@@ -88,4 +88,8 @@ HYPERJUMP_SPEED_SCALE = 3.0
 # Conversion factor from world units to parsecs
 HYPERJUMP_UNIT = 10.0
 # Opacity of the vignette overlay during jumps
-HYPERJUMP_VIGNETTE_ALPHA = 180
+HYPERJUMP_VIGNETTE_ALPHA = 220
+
+# Minimum and maximum duration of hyperjump animations in seconds
+HYPERJUMP_MIN_TIME = 1.0
+HYPERJUMP_MAX_TIME = 60.0

--- a/src/ship.py
+++ b/src/ship.py
@@ -218,6 +218,10 @@ class Ship:
             1 + config.HYPERJUMP_SPEED_SCALE * math.log10(1 + d_pc / config.HYPERJUMP_D0)
         )
         self.hyperjump_anim_time = d_pc / v if v > 0 else 0.0
+        self.hyperjump_anim_time = max(
+            config.HYPERJUMP_MIN_TIME,
+            min(self.hyperjump_anim_time, config.HYPERJUMP_MAX_TIME),
+        )
         self.hyperjump_elapsed = 0.0
         self._hyperjump_start = (self.x, self.y)
         self.autopilot_target = None


### PR DESCRIPTION
## Summary
- clamp hyperjump animation duration between 1 and 60 seconds
- darken hyperjump vignette effect
- document new behaviour in README

## Testing
- `python -m py_compile src/config.py src/ship.py`

------
https://chatgpt.com/codex/tasks/task_e_686899dad4cc8331afdbc2772dcb98e2