### PR TITLE
Increase hyperjump base speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ v(d) = v0 · (1 + k · log10(1 + d / d0))
 t(d) = d / v(d)
 ```
 
-where `v0` is 2.0 pc/s, `d0` is 0.5 pc and `k` is 3.
+where `v0` is 4.0 pc/s, `d0` is 0.5 pc and `k` is 3.
 
 Travel time is clamped between 1 and 60 seconds so even nearby jumps last at
 least a second while distant ones never exceed a minute. The vignette overlay is

--- a/src/config.py
+++ b/src/config.py
@@ -80,8 +80,8 @@ ENEMY_ORBIT_PROBABILITY = 0.35  # chance of starting an orbit each interval
 HYPERJUMP_COOLDOWN = 8.0
 HYPERJUMP_DELAY = 1.0
 # Base hyperjump velocity in parsecs per second
-# Vastly increased base hyperjump velocity (pc/s)
-HYPERJUMP_BASE_SPEED = 2.0
+# Further increased base hyperjump velocity (pc/s)
+HYPERJUMP_BASE_SPEED = 4.0
 # Shorter reference distance for noticeable scaling
 HYPERJUMP_D0 = 0.5
 # Stronger scaling so far targets only take a bit longer


### PR DESCRIPTION
## Summary
- bump up hyperjump speed for faster travel
- document new hyperjump velocity in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68689cba3a188331a9d1920060982d23