### PR TITLE
Add range limit to orbit ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ Five ability slots now appear at the bottom of the screen. The first slot shows
 the **Boost** ability which is still activated with the left **Shift** key. The
 second slot triggers the **Orbit** skill using the **R** key or by clicking the
 slot. When used, your ship orbits the nearest enemy at a reduced speed for five
-seconds and automatically fires once every second. After the orbit ends there
-is a short cooldown before it can be triggered again.
+seconds and automatically fires once every second. The ability only activates
+if an enemy is within 350 pixels. After the orbit ends there is a short
+cooldown before it can be triggered again.
 
 A round **Hyper** button sits to the right of the slots. Clicking it opens a
 large map of the surrounding sectors. Left-click anywhere on the map to place a

--- a/src/config.py
+++ b/src/config.py
@@ -24,6 +24,7 @@ SHIP_ORBIT_SPEED = 1.5      # angular speed for attack orbits (radians per secon
 ORBIT_COOLDOWN = 5.0        # delay before a new orbit can be triggered
 ORBIT_PROJECTILE_SPEED_MULTIPLIER = 2.0  # bullet speed boost while orbiting
 ORBIT_PROJECTILE_CURVATURE = 4.0        # radians per second of bullet curve
+ORBIT_TRIGGER_RANGE = 350   # max distance from an enemy to start an orbit
 PROJECTILE_MAX_DISTANCE = 1200          # maximum distance a projectile can travel
 HOMING_PROJECTILE_TURN_RATE = 6.0       # rad/s a guided projectile can turn
 

--- a/src/main.py
+++ b/src/main.py
@@ -434,7 +434,7 @@ def main():
                         if d < min_dist:
                             min_dist = d
                             nearest = en
-                    if nearest and min_dist <= 350:
+                    if nearest and min_dist <= config.ORBIT_TRIGGER_RANGE:
                         ship.start_orbit(nearest.ship, speed=config.SHIP_ORBIT_SPEED * 0.5)
                 elif event.key == pygame.K_SPACE:
                     mx, my = pygame.mouse.get_pos()

--- a/src/ui.py
+++ b/src/ui.py
@@ -438,7 +438,7 @@ class AbilityBar:
             if d < min_dist:
                 min_dist = d
                 nearest = en
-        if nearest:
+        if nearest and min_dist <= config.ORBIT_TRIGGER_RANGE:
             ship.start_orbit(nearest.ship, speed=config.SHIP_ORBIT_SPEED * 0.5)
 
     def draw(self, screen: pygame.Surface, font: pygame.font.Font) -> None:


### PR DESCRIPTION
## Summary
- configure a new `ORBIT_TRIGGER_RANGE`
- check the distance before calling `start_orbit`
- use the constant in keyboard handler
- document orbit range in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686948815fd88331974bd101151a7682