### PR TITLE
Add artifact support for enemy ships

### DIFF
--- a/src/enemy_learning.py
+++ b/src/enemy_learning.py
@@ -6,7 +6,16 @@ from dataclasses import dataclass, field
 
 from enemy import Enemy, Flee, Defend, Attack, Pursue, Idle, _NullKeys, enemy_manager
 from fraction import FRACTIONS
-from artifact import Decoy
+from artifact import (
+    Decoy,
+    EMPArtifact,
+    AreaShieldArtifact,
+    GravityTractorArtifact,
+    NanobotArtifact,
+    SolarGeneratorArtifact,
+    DecoyArtifact,
+    AVAILABLE_ARTIFACTS,
+)
 from combat import (
     LaserWeapon,
     MineWeapon,
@@ -192,6 +201,7 @@ class LearningEnemy(Enemy):
         state = self._state()
         action = self.choose_action(state)
         self.perform_action(action)
+        self._maybe_use_artifacts(player_ship, dist_to_player)
         self.ship.update(_NullKeys(), dt, world_width, world_height, sectors, blackholes, None)
 
         if (
@@ -226,6 +236,10 @@ def create_learning_enemy(region):
         region,
         fraction,
     )
+    num_artifacts = random.randint(1, 2)
+    art_classes = random.sample(AVAILABLE_ARTIFACTS, num_artifacts)
+    enemy.artifacts = [cls() for cls in art_classes]
+    enemy.ship.artifacts = enemy.artifacts
     enemy.load_q_table()
     # Replace the default weapon with a random one
     weapon_cls = random.choice(


### PR DESCRIPTION
## Summary
- allow Enemy and LearningEnemy to equip artifacts
- grant random artifacts when creating enemies
- enemies occasionally activate their artifacts in combat

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68695834028883318ea2b92527fade9c