### PR TITLE
Add cargo capacity system

### DIFF
--- a/src/character.py
+++ b/src/character.py
@@ -39,6 +39,15 @@ class Player:
         # Inventory starts empty but contains an entry for each known item
         self.inventory: dict[str, int] = {name: 0 for name in ITEMS_BY_NAME}
 
+    @property
+    def cargo_weight(self) -> float:
+        """Total weight of all items carried."""
+        total = 0.0
+        for name, qty in self.inventory.items():
+            item = ITEMS_BY_NAME[name]
+            total += item.peso * qty
+        return total
+
     def add_item(self, item: str, quantity: int = 1) -> None:
         """Add `quantity` of `item` to the inventory."""
         if item not in self.inventory:

--- a/src/ship.py
+++ b/src/ship.py
@@ -36,14 +36,15 @@ class ShipModel:
     size: int
     color: tuple[int, int, int]
     accel_factor: float = 1.0
+    cargo_capacity: float = 0.0
 
 
 # Some predefined ship models used during character creation
 SHIP_MODELS = [
-    ShipModel("Fighter", "AeroTech", 18, (200, 200, 255), 1.2),
-    ShipModel("Explorer", "NovaCorp", 20, (255, 220, 150), 1.0),
-    ShipModel("Freighter", "Galactic Haul", 24, (180, 180, 180), 0.8),
-    ShipModel("Interceptor", "Starlight", 16, (255, 100, 100), 1.4),
+    ShipModel("Fighter", "AeroTech", 18, (200, 200, 255), 1.2, 50.0),
+    ShipModel("Explorer", "NovaCorp", 20, (255, 220, 150), 1.0, 80.0),
+    ShipModel("Freighter", "Galactic Haul", 24, (180, 180, 180), 0.8, 150.0),
+    ShipModel("Interceptor", "Starlight", 16, (255, 100, 100), 1.4, 40.0),
 ]
 
 class Ship:

--- a/src/station.py
+++ b/src/station.py
@@ -60,6 +60,9 @@ class SpaceStation:
             price = int(price * 0.9)
         if player.credits < price:
             return False
+        capacity = getattr(getattr(player, "ship_model", None), "cargo_capacity", float("inf"))
+        if player.cargo_weight + item.peso * qty > capacity:
+            return False
         player.credits -= price
         player.add_item(item_name, qty)
         self.market[item_name] -= qty

--- a/src/ui.py
+++ b/src/ui.py
@@ -139,6 +139,11 @@ class InventoryWindow:
         screen.fill((20, 20, 40))
         title = font.render("Inventory", True, (255, 255, 255))
         screen.blit(title, (20, 20))
+        capacity = getattr(getattr(self.player, "ship_model", None), "cargo_capacity", 0)
+        weight_txt = font.render(
+            f"Cargo: {self.player.cargo_weight:.1f}/{capacity}", True, (255, 255, 255)
+        )
+        screen.blit(weight_txt, (20, 40))
         self.item_rects.clear()
         x0, y0 = 20, 60
         cell_w, cell_h = 120, 40
@@ -196,6 +201,11 @@ class MarketWindow:
         screen.fill((20, 20, 40))
         title = font.render(f"Market - {self.player.credits} cr", True, (255, 255, 255))
         screen.blit(title, (20, 20))
+        cap = getattr(getattr(self.player, "ship_model", None), "cargo_capacity", 0)
+        wt_txt = font.render(
+            f"Cargo: {self.player.cargo_weight:.1f}/{cap}", True, (255, 255, 255)
+        )
+        screen.blit(wt_txt, (20, 40))
 
         self.buy_rects.clear()
         self.sell_rects.clear()


### PR DESCRIPTION
## Summary
- extend `ShipModel` with a `cargo_capacity` field and update default ships
- track carried weight on the `Player` via `cargo_weight`
- prevent purchases exceeding cargo capacity in `SpaceStation`
- show cargo load in inventory and market windows

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68695c5a83908331a01784a27bbc7488