### PR TITLE
Add station market persistence

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,7 @@ from faction_structures import spawn_capital_ships
 from star import Star
 from planet import Planet
 from station import SpaceStation
+from savegame import load_station_markets, save_station_markets
 from ui import (
     DropdownMenu,
     RoutePlanner,
@@ -115,6 +116,8 @@ def main():
     sectors = create_sectors(
         config.GRID_SIZE, config.SECTOR_WIDTH, config.SECTOR_HEIGHT
     )
+    # Restore persistent market data if available
+    load_station_markets(sectors)
     blackholes = []
     wormholes = []
     for sector in sectors:
@@ -763,6 +766,8 @@ def main():
     # Save learning data so enemies retain behavior between sessions
     for enemy in enemies:
         enemy.save_q_table()
+    # Persist station markets for next session
+    save_station_markets(sectors)
 
     pygame.quit()
 

--- a/src/station.py
+++ b/src/station.py
@@ -30,6 +30,8 @@ class SpaceStation:
         self.x = x
         self.y = y
         self.radius = radius
+        # Unique identifier used when saving/loading market data
+        self.id = f"{self.name}_{int(self.x)}_{int(self.y)}"
         self.hangars = [Hangar() for _ in range(num_hangars)]
         self.rooms = [Room(f"Room {i+1}") for i in range(num_rooms)]
         # Randomly populate the market with items for trade


### PR DESCRIPTION
## Summary
- assign a stable `id` to each `SpaceStation` instance
- persist station markets to `station_markets.json`
- restore markets when loading a game
- call new save/load helpers from `main`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68695f7844648331bcf9c041a94b2edd