### PR TITLE
Add solar Dominion capital ship energy arms

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -587,6 +587,8 @@ def main():
                     break
         for sector in sectors:
             sector.update(dt)
+        for cap in capital_ships:
+            cap.update(dt, sectors)
 
         screen.fill(config.BACKGROUND_COLOR)
         if route_planner.active:


### PR DESCRIPTION
## Summary
- add `ChannelArm` dataclass for capital ship energy beams
- extend `CapitalShip` with arms and aura radius
- update/draw Solar Dominion capital ships with energy arms and aura
- call new `CapitalShip.update` from game loop

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869d0c23d8c8331ba1f300599404ef3