### PR TITLE
Increase Solar Dominion capital aura radius

### DIFF
--- a/src/faction_structures.py
+++ b/src/faction_structures.py
@@ -61,7 +61,7 @@ class CapitalShip(FactionStructure):
         if fraction.name == "Solar Dominion":
             self.hull = 1500
             self.modules.extend(["Heavy Cannons", "Fighter Bays"])
-            self.aura_radius = 120
+            self.aura_radius = 240
             self.radius = max(self.radius, self.aura_radius)
             self.arms = [
                 ChannelArm(i * 2 * math.pi / 5, self.radius)


### PR DESCRIPTION
## Summary
- adjust Solar Dominion capital ship aura radius to 240

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6869da3af75c8331b1c7f6b418296af8