### PR TITLE
Fix syntax in CapitalShip.draw

### DIFF
--- a/src/faction_structures.py
+++ b/src/faction_structures.py
@@ -177,7 +177,12 @@ class CapitalShip(FactionStructure):
                 (x, y + scaled // 2 + thr // 2),
             ]
             for lx, ly in lights:
-                pygame.draw.circle(screen, flash, (lx, ly), max(2, int(3 * zoom))
+                pygame.draw.circle(
+                    screen,
+                    flash,
+                    (lx, ly),
+                    max(2, int(3 * zoom))
+                )
         elif self.fraction and self.fraction.name == "Nebula Order":
             outer = tuple(int(c * 0.6) for c in color)
             middle = color
@@ -195,7 +200,12 @@ class CapitalShip(FactionStructure):
                 (x - mid_r, y),
             ]
             for dx, dy in dots:
-                pygame.draw.circle(screen, (0, 0, 0), (dx, dy), max(2, int(3 * zoom)) main
+                pygame.draw.circle(
+                    screen,
+                    (0, 0, 0),
+                    (dx, dy),
+                    max(2, int(3 * zoom))
+                )
         elif self.shape == "angular":
             # square hull with triangular wings
             hull = pygame.Rect(x - scaled // 2, y - scaled // 2, scaled, scaled)


### PR DESCRIPTION
## Summary
- fix missing parentheses in CapitalShip.draw lights and dots loops

## Testing
- `python -m py_compile src/faction_structures.py`


------
https://chatgpt.com/codex/tasks/task_e_6869f0d4ce7c8331b131c749832567d8