### PR TITLE
Add Nebula Order drone mechanics

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -589,7 +589,7 @@ def main():
             sector.update(dt)
         # Update roaming capital ships so their arms can track nearby stars
         for cap in capital_ships:
-            cap.update(dt, sectors)
+            cap.update(dt, sectors, enemies)
 
         screen.fill(config.BACKGROUND_COLOR)
         if route_planner.active:


### PR DESCRIPTION
## Summary
- add `drones` field to `CapitalShip`
- spawn drones when Nebula Order traits are applied
- update/draw Nebula Order capital ships to handle drones
- pass hostile enemies to `CapitalShip.update` calls

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6869f6e5da0c833197241a9f74c84ca2