### PR TITLE
Add defensive drones for Nebula Order flagship

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ button to return to space.
   purple outer hull, a mid purple ring with black markers at the cardinal
   points, and a light purple core. A thick golden **Engagement Ring** encircles
   the ship to host diplomats and other non-scientists.
+* The flagship also fields defensive drones that orbit the vessel and intercept
+  nearby threats.
 
 ## Character creation
 

--- a/src/defensive_drone.py
+++ b/src/defensive_drone.py
@@ -1,0 +1,75 @@
+import math
+import pygame
+
+
+class DefensiveDrone:
+    """Simple defensive drone that orbits its owner and intercepts threats."""
+
+    def __init__(
+        self,
+        owner,
+        angle: float = 0.0,
+        orbit_radius: float | None = None,
+        orbit_speed: float = 0.8,
+        hp: float = 20.0,
+    ) -> None:
+        self.owner = owner
+        self.angle = angle
+        self.orbit_speed = orbit_speed
+        self.orbit_radius = orbit_radius or owner.size * 3
+        self.intercept_speed = 180.0
+        self.hp = hp
+        self.size = 12
+        self.x = owner.x + math.cos(angle) * self.orbit_radius
+        self.y = owner.y + math.sin(angle) * self.orbit_radius
+        self.state = "idle"
+        self.target = None
+
+    def _find_threat(self, enemies: list) -> object | None:
+        detection = self.owner.size * 6
+        for en in enemies:
+            dist = math.hypot(en.ship.x - self.owner.x, en.ship.y - self.owner.y)
+            if dist <= detection:
+                return en.ship
+            for proj in en.ship.projectiles:
+                d = math.hypot(proj.x - self.owner.x, proj.y - self.owner.y)
+                if d <= detection:
+                    return proj
+        return None
+
+    def update(self, dt: float, enemies: list) -> None:
+        if self.state == "idle":
+            self.angle += self.orbit_speed * dt
+            self.x = self.owner.x + math.cos(self.angle) * self.orbit_radius
+            self.y = self.owner.y + math.sin(self.angle) * self.orbit_radius
+            threat = self._find_threat(enemies)
+            if threat:
+                self.target = threat
+                self.state = "intercept"
+        else:
+            if isinstance(self.target, object):
+                tx = getattr(self.target, "x", self.owner.x)
+                ty = getattr(self.target, "y", self.owner.y)
+            else:
+                tx, ty = self.owner.x, self.owner.y
+            dx = tx - self.x
+            dy = ty - self.y
+            dist = math.hypot(dx, dy) or 1.0
+            self.x += (dx / dist * self.intercept_speed) * dt
+            self.y += (dy / dist * self.intercept_speed) * dt
+            if dist <= self.size * 1.2:
+                self.state = "idle"
+                self.target = None
+        max_dist = self.orbit_radius * 3
+        d_from_owner = math.hypot(self.x - self.owner.x, self.y - self.owner.y)
+        if d_from_owner > max_dist:
+            angle = math.atan2(self.y - self.owner.y, self.x - self.owner.x)
+            self.x = self.owner.x + math.cos(angle) * max_dist
+            self.y = self.owner.y + math.sin(angle) * max_dist
+
+    def expired(self) -> bool:
+        return self.hp <= 0
+
+    def draw(self, screen: pygame.Surface, offset_x: float = 0.0, offset_y: float = 0.0, zoom: float = 1.0) -> None:
+        pos = (int((self.x - offset_x) * zoom), int((self.y - offset_y) * zoom))
+        pygame.draw.circle(screen, (100, 180, 255), pos, max(2, int(5 * zoom)))


### PR DESCRIPTION
## Summary
- add a `DefensiveDrone` class that orbits a structure and intercepts threats
- spawn a trio of defensive drones for the Nebula Order flagship
- update and draw drones in `CapitalShip`
- document defensive drones in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686ad9d630c083318514bf9958c95124