### PR TITLE
Fix drone collision freeze

### DIFF
--- a/src/ship.py
+++ b/src/ship.py
@@ -396,6 +396,9 @@ class Ship:
             if math.hypot(other.x - self.x, other.y - self.y) < half_size + other.size / 2:
                 return True
         for struct in self._structures:
+            # Skip small drones so they don't trap the player when colliding.
+            if isinstance(struct, Drone):
+                continue
             # Drones only provide ``size`` representing their collision radius,
             # while larger structures expose a ``radius`` attribute. Handle both
             # so ships properly avoid them.


### PR DESCRIPTION
## Summary
- prevent player immobilization when Nebula Order drones make contact

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686af7e64c8883318aac1a54d016b648