### PR TITLE
Fix enemy weapon cooldown assignment

### DIFF
--- a/src/enemy.py
+++ b/src/enemy.py
@@ -286,6 +286,6 @@ def create_random_enemy(region: Sector) -> Enemy:
     enemy.ship.weapons = [weapon_cls()]
     for w in enemy.ship.weapons:
         w.owner = enemy.ship
-        # Use a configurable cooldown so enemies don't spam shots
-        w.cooldown = config.ENEMY_WEAPON_COOLDOWN
+        # Only adjust cooldown if the weapon fires too quickly
+        w.cooldown = max(w.cooldown, config.ENEMY_WEAPON_COOLDOWN)
     return enemy

--- a/src/enemy_learning.py
+++ b/src/enemy_learning.py
@@ -225,6 +225,6 @@ def create_learning_enemy(region):
     enemy.ship.weapons = [weapon_cls()]
     for w in enemy.ship.weapons:
         w.owner = enemy.ship
-        # Set the weapon cooldown using the configured value
-        w.cooldown = config.ENEMY_WEAPON_COOLDOWN
+        # Ensure minimum cooldown so the enemy can't fire too rapidly
+        w.cooldown = max(w.cooldown, config.ENEMY_WEAPON_COOLDOWN)
     return enemy


### PR DESCRIPTION
## Summary
- ensure weapon cooldown is not overridden if the default is higher
- same logic for learning enemies

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686b0bb0e0e08331af2673b0418b6cc9