### PR TITLE
Implement star energy recharge system

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,3 +156,14 @@ Three additional artifacts expand your tactical options:
 Press **G** to open the artifact menu. All available artifacts are listed and
 clicking one lets you choose the ability slot by pressing **1**, **2** or **3**.
 The first two slots (Boost and Orbit) cannot be replaced.
+
+### Energy and the Dyson Sphere
+
+Stars now carry a vast reserve of power through a new `energy` attribute.
+Capital ships include matching `energy` and `max_energy` values which default
+to 10&nbsp;000 units. Solar Dominion flagships start with their energy bar full
+thanks to the channel arms that surround them. Each arm links to a nearby star
+and transfers roughly 100 energy per second while the link is maintained,
+reducing the star's own supply. This mechanism lays the groundwork for
+constructing a Dyson Sphere that continuously harvests stellar energy for the
+faction's fleet.

--- a/src/faction_structures.py
+++ b/src/faction_structures.py
@@ -104,6 +104,8 @@ class CapitalShip(FactionStructure):
     y: float = 0.0
     hull: int = 1000
     hangar_capacity: int = 4
+    energy: float = 0.0
+    max_energy: float = 10000.0
     energy_sources: list[Any] = field(default_factory=list)
     # Basic collision/scale size used by drones and other systems
     size: int = 50
@@ -125,6 +127,8 @@ class CapitalShip(FactionStructure):
             self.radius = max(self.radius, self.aura_radius)
             # Update size after modifying the radius
             self.size = self.radius
+            # Solar Dominion ships start fully charged
+            self.energy = self.max_energy
             self.arms = [
                 ChannelArm(i * 2 * math.pi / 5, self.radius)
                 for i in range(5)
@@ -199,6 +203,14 @@ class CapitalShip(FactionStructure):
                     else:
                         arm.angle += rotate if diff > 0 else -rotate
                     arm.angle %= 2 * math.pi
+                    # Recharge energy from the linked star
+                    if self.energy < self.max_energy:
+                        transfer = 100.0 * dt
+                        available = min(transfer, arm.target.energy)
+                        needed = self.max_energy - self.energy
+                        amount = min(available, needed)
+                        self.energy += amount
+                        arm.target.energy -= amount
         elif self.fraction.name == "Nebula Order":
             hostiles = [e for e in enemies if e.fraction != self.fraction]
             if player and getattr(player, "fraction", None) != self.fraction:

--- a/src/star.py
+++ b/src/star.py
@@ -36,6 +36,8 @@ class Star:
         self.color = color
         self.spectral_type = spectral_type
         self.brightness = brightness if brightness is not None else radius * 10
+        # Available energy that can be channelled by other structures
+        self.energy = 1_000_000_000.0
 
     @staticmethod
     def random_star(x: float, y: float) -> "Star":


### PR DESCRIPTION
## Summary
- give `Star` objects a large starting energy store
- track `energy` and `max_energy` on capital ships
- start Solar Dominion flagships fully charged
- recharge energy via `ChannelArm` links
- document the new energy system and Dyson Sphere plan

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686b11ff1aac83319534ec576b1b7654