### PR TITLE
Adjust energy transfer speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Stars now carry a vast reserve of power through a new `energy` attribute.
 Capital ships include matching `energy` and `max_energy` values which default
 to 10&nbsp;000 units. Solar Dominion flagships start with their energy bar full
 thanks to the channel arms that surround them. Each arm links to a nearby star
-and transfers roughly 100 energy per second while the link is maintained,
+and transfers roughly 10 energy per second while the link is maintained,
 reducing the star's own supply. This mechanism lays the groundwork for
 constructing a Dyson Sphere that continuously harvests stellar energy for the
 faction's fleet.

--- a/src/faction_structures.py
+++ b/src/faction_structures.py
@@ -205,7 +205,10 @@ class CapitalShip(FactionStructure):
                     arm.angle %= 2 * math.pi
                     # Recharge energy from the linked star
                     if self.energy < self.max_energy:
-                        transfer = 100.0 * dt
+                        # Each channel arm can move up to 10 energy units per
+                        # second from its linked star, limited by the star's
+                        # remaining energy and the ship's current deficit.
+                        transfer = 10.0 * dt
                         available = min(transfer, arm.target.energy)
                         needed = self.max_energy - self.energy
                         amount = min(available, needed)


### PR DESCRIPTION
## Summary
- tune channel arm transfer rate to 10 energy per second
- document reduced transfer rate in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686b1386e1f08331b39840c2e88c787f