### PR TITLE
Increase ship inertia and enemy drift

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -5,7 +5,9 @@ SHIP_COLOR = (255, 255, 255)
 SHIP_SIZE = 20
 # Ship acceleration is drastically increased for snappier movement
 SHIP_ACCELERATION = 300  # pixels per second squared (5x default)
-SHIP_FRICTION = 0.92  # velocity retained each frame
+# Increased friction value so ships retain more of their velocity each frame,
+# giving them a noticeably longer drift after moving.
+SHIP_FRICTION = 0.96  # velocity retained each frame
 AUTOPILOT_SPEED = 120  # pixels per second when auto moving
 PLANET_LANDING_SPEED = 100  # slower speed when approaching a planet
 

--- a/src/ship.py
+++ b/src/ship.py
@@ -343,20 +343,21 @@ class Ship:
         dx = dest_x - self.x
         dy = dest_y - self.y
         distance = math.hypot(dx, dy)
-        step = config.AUTOPILOT_SPEED * dt
+        speed = config.AUTOPILOT_SPEED
         if isinstance(self.autopilot_target, Planet):
-            step = config.PLANET_LANDING_SPEED * dt
+            speed = config.PLANET_LANDING_SPEED
+        step = speed * dt
         if distance <= step:
             self.x = dest_x
             self.y = dest_y
             self.autopilot_target = None
-            self.vx = 0
-            self.vy = 0
             return
-        self.angle = math.atan2(dy, dx)
+        self.vx = dx / distance * speed
+        self.vy = dy / distance * speed
+        self.angle = math.atan2(self.vy, self.vx)
         old_x, old_y = self.x, self.y
-        self.x += dx / distance * step
-        self.y += dy / distance * step
+        self.x += self.vx * dt
+        self.y += self.vy * dt
         self.x = max(0, min(world_width, self.x))
         self.y = max(0, min(world_height, self.y))
         self._emit_particle()


### PR DESCRIPTION
## Summary
- tweak `SHIP_FRICTION` so velocity is retained longer
- allow autopilot movement to leave residual velocity for drifting

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686b1aafd4988331ad23584bae1792d9