### PR TITLE
Fix Nebula Order drones friendly fire

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -585,7 +585,9 @@ def main():
             sector.update(dt)
         # Update roaming capital ships so their arms can track nearby stars
         for cap in capital_ships:
-            cap.update(dt, sectors, enemies, ship)
+            # Pass the player object so capital ships know the player's
+            # faction when determining hostiles
+            cap.update(dt, sectors, enemies, player)
 
         screen.fill(config.BACKGROUND_COLOR)
         if route_planner.active:


### PR DESCRIPTION
## Summary
- ensure Nebula Order drones treat player as friendly when factions match

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686b306436a083318d24d8721e11bb7f