### PR TITLE
Add Cosmic Guild city stations

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -496,6 +496,11 @@ def main():
 
         keys = pygame.key.get_pressed()
         hostiles = [en for en in enemies if en.fraction != player.fraction]
+        structures = []
+        for cap in capital_ships:
+            structures.append(cap)
+            structures.extend(cap.city_stations)
+
         ship.update(
             keys,
             dt,
@@ -504,7 +509,7 @@ def main():
             sectors,
             blackholes,
             hostiles,
-            capital_ships,
+            structures,
         )
         for enemy in list(enemies):
             enemy.update(
@@ -514,7 +519,7 @@ def main():
                 world_height,
                 sectors,
                 blackholes,
-                capital_ships,
+                structures,
             )
 
             enemy_radius = enemy.ship.collision_radius


### PR DESCRIPTION
## Summary
- add `city_stations` attribute to `CapitalShip`
- spawn several `SpaceStation` objects around Cosmic Guild flagships
- draw stations and include them in collision detection
- update `spawn_capital_ships` to set coordinates before applying traits
- pass all capital ship structures to ship update loops

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686b37047a7883318f460e8b68097ea4