### PR TITLE
Lower NPC ship speeds

### DIFF
--- a/src/aggressive_defensive_drone.py
+++ b/src/aggressive_defensive_drone.py
@@ -13,8 +13,9 @@ class AggressiveDefensiveDrone(Drone):
         hp: float = 40.0,
         fire_cooldown: float = 0.2,
         orbit_speed: float = 1.0,
+        speed_factor: float = 1.0,
     ) -> None:
-        super().__init__(owner, hp=hp, orbit_speed=orbit_speed)
+        super().__init__(owner, hp=hp, orbit_speed=orbit_speed, speed_factor=speed_factor)
         self.radius = radius
         self.fire_cooldown = fire_cooldown
 

--- a/src/combat.py
+++ b/src/combat.py
@@ -444,13 +444,14 @@ class Drone:
         hp: float = 16.0,
         lifetime: float = float("inf"),
         orbit_speed: float = 2.0,
+        speed_factor: float = 1.0,
     ) -> None:
         self.owner = owner
         self.angle = 0.0
         # Increased orbit range so drones keep a bit more distance
         # and engage targets from farther away
         self.radius = owner.size * 4
-        self.orbit_speed = orbit_speed
+        self.orbit_speed = orbit_speed * speed_factor
         self.hp = hp
         self.lifetime = lifetime
         self.size = 10
@@ -556,7 +557,7 @@ class DroneWeapon(Weapon):
         if len(existing) >= 3:
             return None
         self._timer = 0.0
-        return Drone(self.owner)
+        return Drone(self.owner, speed_factor=config.NPC_SPEED_FACTOR)
 
 
 class MissileWeapon(Weapon):

--- a/src/config.py
+++ b/src/config.py
@@ -83,6 +83,9 @@ ENEMY_WEAPON_COOLDOWN = 0.3
 ENEMY_ORBIT_INTERVAL = 12.0  # seconds between orbit attempts
 ENEMY_ORBIT_PROBABILITY = 0.35  # chance of starting an orbit each interval
 
+# Speed multiplier applied to all computer controlled ships and drones
+NPC_SPEED_FACTOR = 0.85
+
 # --- Hyperjump settings ------------------------------------------------------
 # Delay before a hyperjump completes and cooldown between jumps
 HYPERJUMP_COOLDOWN = 8.0

--- a/src/defensive_drone.py
+++ b/src/defensive_drone.py
@@ -13,14 +13,15 @@ class DefensiveDrone:
         orbit_radius: float | None = None,
         orbit_speed: float = config.DEF_DRONE_ORBIT_SPEED,
         hp: float = 20.0,
+        speed_factor: float = 1.0,
     ) -> None:
         self.owner = owner
         self.angle = angle
-        self.orbit_speed = orbit_speed
+        self.orbit_speed = orbit_speed * speed_factor
         self.orbit_radius = (
             orbit_radius or owner.size * config.DEF_DRONE_ORBIT_RADIUS_FACTOR
         )
-        self.intercept_speed = config.DEF_DRONE_INTERCEPT_SPEED
+        self.intercept_speed = config.DEF_DRONE_INTERCEPT_SPEED * speed_factor
         self.hp = hp
         self.size = 12
         self.x = owner.x + math.cos(angle) * self.orbit_radius

--- a/src/enemy.py
+++ b/src/enemy.py
@@ -274,7 +274,13 @@ def create_random_enemy(region: Sector) -> Enemy:
     y = random.randint(region.y, region.y + region.height)
     fraction = random.choice(FRACTIONS)
     enemy = Enemy(
-        Ship(x, y, model, hull=config.ENEMY_MAX_HULL),
+        Ship(
+            x,
+            y,
+            model,
+            hull=config.ENEMY_MAX_HULL,
+            speed_factor=config.NPC_SPEED_FACTOR,
+        ),
         species,
         region,
         fraction,

--- a/src/enemy_learning.py
+++ b/src/enemy_learning.py
@@ -212,7 +212,13 @@ def create_learning_enemy(region):
     y = random.randint(region.y, region.y + region.height)
     fraction = random.choice(FRACTIONS)
     enemy = LearningEnemy(
-        Ship(x, y, model, hull=config.ENEMY_MAX_HULL),
+        Ship(
+            x,
+            y,
+            model,
+            hull=config.ENEMY_MAX_HULL,
+            speed_factor=config.NPC_SPEED_FACTOR,
+        ),
         species,
         region,
         fraction,

--- a/src/faction_structures.py
+++ b/src/faction_structures.py
@@ -11,6 +11,7 @@ from learning_defensive_drone import LearningDefensiveDrone
 from aggressive_defensive_drone import AggressiveDefensiveDrone
 from station import SpaceStation
 import pygame
+import config
 
 
 @dataclass
@@ -230,6 +231,7 @@ class CapitalShip(FactionStructure):
                     self,
                     ring_radius,
                     orbit_speed=-0.75,
+                    speed_factor=config.NPC_SPEED_FACTOR,
                 )
                 drone.angle = i * 2 * math.pi / 10
                 self.drones.append(drone)

--- a/src/learning_defensive_drone.py
+++ b/src/learning_defensive_drone.py
@@ -42,6 +42,7 @@ class LearningDefensiveDrone(DefensiveDrone):
             self.orbit_radius,
             self.orbit_speed,
             self.hp,
+            speed_factor=config.NPC_SPEED_FACTOR,
         )
 
     def load_q_table(self, path: str = Q_TABLE_PATH) -> None:

--- a/src/ship.py
+++ b/src/ship.py
@@ -74,6 +74,7 @@ class Ship:
         y: float,
         model: ShipModel | None = None,
         hull: int = 100,
+        speed_factor: float = 1.0,
     ) -> None:
         self.x = float(x)
         self.y = float(y)
@@ -84,7 +85,8 @@ class Ship:
         self.orbit_time = 0.0
         self.orbit_radius = 0.0
         self.orbit_angle = 0.0
-        self.orbit_speed = config.SHIP_ORBIT_SPEED
+        self.speed_factor = speed_factor
+        self.orbit_speed = config.SHIP_ORBIT_SPEED * self.speed_factor
         self.orbit_fire_timer = 0.0
         self.orbit_cooldown = 0.0
         self.orbit_forced = False
@@ -183,7 +185,7 @@ class Ship:
             self._update_autopilot(dt, world_width, world_height, sectors, blackholes)
             return
 
-        accel = config.SHIP_ACCELERATION * self.accel_factor
+        accel = config.SHIP_ACCELERATION * self.accel_factor * self.speed_factor
         if self.boost_time > 0:
             self.boost_time -= dt
             if self.boost_time <= 0:
@@ -282,7 +284,8 @@ class Ship:
         self.orbit_target = target
         self.orbit_time = duration
         self.orbit_forced = forced
-        self.orbit_speed = speed if speed is not None else config.SHIP_ORBIT_SPEED
+        base_speed = speed if speed is not None else config.SHIP_ORBIT_SPEED
+        self.orbit_speed = base_speed * self.speed_factor
         self.orbit_fire_timer = 0.0
         self.autopilot_target = None
 
@@ -290,7 +293,7 @@ class Ship:
         self.orbit_target = None
         self.orbit_time = 0.0
         self.orbit_forced = False
-        self.orbit_speed = config.SHIP_ORBIT_SPEED
+        self.orbit_speed = config.SHIP_ORBIT_SPEED * self.speed_factor
         self.orbit_fire_timer = 0.0
         self.orbit_cooldown = config.ORBIT_COOLDOWN
 
@@ -343,9 +346,9 @@ class Ship:
         dx = dest_x - self.x
         dy = dest_y - self.y
         distance = math.hypot(dx, dy)
-        speed_limit = config.AUTOPILOT_SPEED
+        speed_limit = config.AUTOPILOT_SPEED * self.speed_factor
         if isinstance(self.autopilot_target, Planet):
-            speed_limit = config.PLANET_LANDING_SPEED
+            speed_limit = config.PLANET_LANDING_SPEED * self.speed_factor
         step = speed_limit * dt
         if distance <= step:
             self.x = dest_x
@@ -356,7 +359,7 @@ class Ship:
             return
 
         angle = math.atan2(dy, dx)
-        accel = config.SHIP_ACCELERATION * self.accel_factor
+        accel = config.SHIP_ACCELERATION * self.accel_factor * self.speed_factor
         self.vx += math.cos(angle) * accel * dt
         self.vy += math.sin(angle) * accel * dt
         vel = math.hypot(self.vx, self.vy)


### PR DESCRIPTION
## Summary
- apply a global `NPC_SPEED_FACTOR` of 0.85
- use this multiplier for enemy ship creation and drones
- scale autopilot and orbit movement by the new factor

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686b3c2968f48331ba69fc6443f8e6ea