### PR TITLE
Implement carrier loading and ally highlight

### DIFF
--- a/src/carrier.py
+++ b/src/carrier.py
@@ -19,7 +19,7 @@ class Carrier(Ship):
         hull: int = 350,
         fraction: Fraction | None = None,
     ) -> None:
-        super().__init__(x, y, model, hull=hull, speed_factor=0.7)
+        super().__init__(x, y, model, hull=hull, speed_factor=0.7, fraction=fraction)
         self.fraction = fraction
         self.hangars = [None] * 5
 

--- a/src/enemy.py
+++ b/src/enemy.py
@@ -280,6 +280,7 @@ def create_random_enemy(region: Sector) -> Enemy:
             model,
             hull=config.ENEMY_MAX_HULL,
             speed_factor=config.NPC_SPEED_FACTOR,
+            fraction=fraction,
         ),
         species,
         region,

--- a/src/enemy_learning.py
+++ b/src/enemy_learning.py
@@ -218,6 +218,7 @@ def create_learning_enemy(region):
             model,
             hull=config.ENEMY_MAX_HULL,
             speed_factor=config.NPC_SPEED_FACTOR,
+            fraction=fraction,
         ),
         species,
         region,


### PR DESCRIPTION
## Summary
- mark each `Ship` with a `fraction`
- highlight allied ships with a translucent circle
- spawn a carrier and some friendly ships in `main`
- add mode to load allied ships into the carrier
- update enemies and carrier to use ship fractions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686b44f0bf6c8331b66ae85ce39640c3