### PR TITLE
Add optional aura color for ally ships

### DIFF
--- a/src/carrier.py
+++ b/src/carrier.py
@@ -44,6 +44,7 @@ class Carrier(Ship):
         offset_x: float = 0.0,
         offset_y: float = 0.0,
         zoom: float = 1.0,
+        aura_color: tuple[int, int, int] | None = None,
     ) -> None:
         color = self.color if self.fraction is None else self.fraction.color
         outline = tuple(max(0, c - 50) for c in color)
@@ -58,7 +59,8 @@ class Carrier(Ship):
         if player_fraction and self.fraction and player_fraction == self.fraction:
             aura_r = int(max(width, height) * 0.8)
             aura = pygame.Surface((aura_r * 2, aura_r * 2), pygame.SRCALPHA)
-            pygame.draw.circle(aura, color + (80,), (aura_r, aura_r), aura_r)
+            aura_col = aura_color or color
+            pygame.draw.circle(aura, aura_col + (80,), (aura_r, aura_r), aura_r)
             screen.blit(aura, (cx - aura_r, cy - aura_r))
 
 __all__ = ["Carrier"]

--- a/src/main.py
+++ b/src/main.py
@@ -711,7 +711,14 @@ def main():
             sector.draw(screen, offset_x, offset_y, zoom)
         for cap in capital_ships:
             cap.draw(screen, offset_x, offset_y, zoom)
-        carrier.draw(screen, player.fraction, offset_x, offset_y, zoom)
+        carrier.draw(
+            screen,
+            player.fraction,
+            offset_x,
+            offset_y,
+            zoom,
+            aura_color=player.fraction.color if player.fraction else None,
+        )
         for ally in friendly_ships:
             ally.draw_projectiles(screen, offset_x, offset_y, zoom)
         for enemy in enemies:
@@ -719,7 +726,14 @@ def main():
         ship.draw_projectiles(screen, offset_x, offset_y, zoom)
         ship.draw_specials(screen, offset_x, offset_y, zoom)
         for ally in friendly_ships:
-            ally.draw_at(screen, offset_x, offset_y, zoom, player.fraction)
+            ally.draw_at(
+                screen,
+                offset_x,
+                offset_y,
+                zoom,
+                player.fraction,
+                player.fraction.color if player.fraction else None,
+            )
         for enemy in enemies:
             enemy.ship.draw_at(screen, offset_x, offset_y, zoom)
             draw_enemy_health_bar(screen, enemy.ship, offset_x, offset_y, zoom)

--- a/src/ship.py
+++ b/src/ship.py
@@ -491,6 +491,7 @@ class Ship:
         screen: pygame.Surface,
         zoom: float = 1.0,
         player_fraction: Fraction | None = None,
+        aura_color: tuple[int, int, int] | None = None,
     ) -> None:
         """Draw the ship scaled by a non-linear factor of the zoom level."""
         cx = config.WINDOW_WIDTH // 2
@@ -507,7 +508,9 @@ class Ship:
         ):
             r = int(self.collision_radius * zoom * 1.4)
             aura = pygame.Surface((r * 2, r * 2), pygame.SRCALPHA)
-            color = self.fraction.color if self.fraction else self.color
+            color = aura_color or (
+                self.fraction.color if self.fraction else self.color
+            )
             pygame.draw.circle(aura, color + (80,), (r, r), r)
             screen.blit(aura, (cx - r, cy - r))
 
@@ -756,6 +759,7 @@ class Ship:
         offset_y: float = 0.0,
         zoom: float = 1.0,
         player_fraction: Fraction | None = None,
+        aura_color: tuple[int, int, int] | None = None,
     ) -> None:
         """Draw the ship on screen applying an offset and zoom."""
         if self.invisible_timer > 0:
@@ -772,7 +776,9 @@ class Ship:
         ):
             r = int(self.collision_radius * zoom * 1.4)
             aura = pygame.Surface((r * 2, r * 2), pygame.SRCALPHA)
-            color = self.fraction.color if self.fraction else self.color
+            color = aura_color or (
+                self.fraction.color if self.fraction else self.color
+            )
             pygame.draw.circle(aura, color + (80,), (r, r), r)
             screen.blit(aura, (cx - r, cy - r))
 


### PR DESCRIPTION
## Summary
- support optional `aura_color` in `Ship.draw` and `Ship.draw_at`
- allow `Carrier.draw` to accept aura color
- draw allies and carriers with the player's aura color

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b496dc7d883319eab9d47af4298cc