### PR TITLE
Reduce ship speed for all factions

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -8,8 +8,11 @@ SHIP_ACCELERATION = 300  # pixels per second squared (5x default)
 # Increased friction value so ships retain more of their velocity each frame,
 # giving them a noticeably longer drift after moving.
 SHIP_FRICTION = 0.96  # velocity retained each frame
-AUTOPILOT_SPEED = 120  # pixels per second when auto moving
-PLANET_LANDING_SPEED = 100  # slower speed when approaching a planet
+# Maximum travel speed for manual control
+SHIP_MAX_SPEED = 100
+# Slightly slower autopilot speed to keep movement moderate
+AUTOPILOT_SPEED = 100  # pixels per second when auto moving
+PLANET_LANDING_SPEED = 80  # slower speed when approaching a planet
 
 # --- Hull settings -----------------------------------------------------------
 # Maximum hull values for player and enemy ships
@@ -84,7 +87,8 @@ ENEMY_ORBIT_INTERVAL = 12.0  # seconds between orbit attempts
 ENEMY_ORBIT_PROBABILITY = 0.35  # chance of starting an orbit each interval
 
 # Speed multiplier applied to all computer controlled ships and drones
-NPC_SPEED_FACTOR = 0.85
+# Use the same speed factor for all ships so they travel evenly
+NPC_SPEED_FACTOR = 1.0
 
 # --- Hyperjump settings ------------------------------------------------------
 # Delay before a hyperjump completes and cooldown between jumps

--- a/src/main.py
+++ b/src/main.py
@@ -137,6 +137,7 @@ def main():
         chosen_model,
         hull=config.PLAYER_MAX_HULL,
         fraction=player.fraction,
+        speed_factor=config.NPC_SPEED_FACTOR,
     )
     ship.weapons.extend([
         LaserWeapon(),
@@ -158,8 +159,14 @@ def main():
     ability_bar.set_ship(ship)
     carrier = Carrier(ship.x + 150, ship.y + 80, fraction=player.fraction)
     friendly_ships = [
-        Ship(carrier.x + random.randint(-60, 60), carrier.y + random.randint(-60, 60),
-             chosen_model, hull=80, fraction=player.fraction)
+        Ship(
+            carrier.x + random.randint(-60, 60),
+            carrier.y + random.randint(-60, 60),
+            chosen_model,
+            hull=80,
+            fraction=player.fraction,
+            speed_factor=config.NPC_SPEED_FACTOR,
+        )
         for _ in range(2)
     ]
     inventory_window = None

--- a/src/ship.py
+++ b/src/ship.py
@@ -214,6 +214,16 @@ class Ship:
         self.vx *= config.SHIP_FRICTION
         self.vy *= config.SHIP_FRICTION
 
+        # Clamp velocity to a moderate maximum so all ships travel evenly
+        speed_limit = config.SHIP_MAX_SPEED * self.speed_factor
+        if self.boost_time > 0:
+            speed_limit *= config.BOOST_MULTIPLIER
+        vel = math.hypot(self.vx, self.vy)
+        if vel > speed_limit:
+            scale = speed_limit / vel
+            self.vx *= scale
+            self.vy *= scale
+
         if abs(self.vx) > 1e-3 or abs(self.vy) > 1e-3:
             self.angle = math.atan2(self.vy, self.vx)
             if abs(self.vx) > 40 or abs(self.vy) > 40:


### PR DESCRIPTION
## Summary
- slow down autopilot speed and planetary landing speed
- add `SHIP_MAX_SPEED` limit and apply in `Ship.update`
- standardize player and ally speed using `NPC_SPEED_FACTOR`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686b4a5a985c83318b02a116e0511d20