### PR TITLE
Fix self-collision in ship collision check

### DIFF
--- a/src/ship.py
+++ b/src/ship.py
@@ -466,6 +466,8 @@ class Ship:
             # Skip small drones so they don't trap the player when colliding.
             if isinstance(struct, Drone):
                 continue
+            if struct is self:
+                continue
             # Drones only provide ``size`` representing their collision radius,
             # while larger structures expose a ``radius`` attribute. Handle both
             # so ships properly avoid them.


### PR DESCRIPTION
## Summary
- avoid self-collisions when a ship is present in the structures list

## Testing
- `python -m py_compile src/ship.py`
- `python src/main.py --help` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_686b4ef7df588331a431f3105251df8c