### PR TITLE
Add ship markers to jump and carrier maps

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -326,8 +326,13 @@ def main():
                 closed = carrier_window.handle_event(event)
                 if closed:
                     if carrier_window.request_move:
+                        move_objects = [ship] + friendly_ships + [en.ship for en in enemies] + capital_ships
                         carrier_move_map = CarrierMoveMap(
-                            carrier, sectors, world_width, world_height
+                            carrier,
+                            sectors,
+                            world_width,
+                            world_height,
+                            move_objects,
                         )
                         carrier_window.request_move = False
                     carrier_window = None
@@ -452,7 +457,14 @@ def main():
 
             route_planner.handle_event(event, sectors, (camera_x, camera_y), zoom)
             if ability_bar.handle_event(event, ship, enemies):
-                hyper_map = HyperJumpMap(ship, sectors, world_width, world_height)
+                map_objects = [carrier] + friendly_ships + [en.ship for en in enemies] + capital_ships
+                hyper_map = HyperJumpMap(
+                    ship,
+                    sectors,
+                    world_width,
+                    world_height,
+                    map_objects,
+                )
 
             if pending_tractor is None:
                 for art in ship.artifacts:

--- a/src/ui.py
+++ b/src/ui.py
@@ -464,11 +464,19 @@ class AbilityBar:
 class HyperJumpMap:
     """Interactive map for selecting hyperjump destinations."""
 
-    def __init__(self, ship, sectors, world_w: int, world_h: int) -> None:
+    def __init__(
+        self,
+        ship,
+        sectors,
+        world_w: int,
+        world_h: int,
+        objects: list | None = None,
+    ) -> None:
         self.ship = ship
         self.sectors = sectors
         self.world_w = world_w
         self.world_h = world_h
+        self.objects = objects or []
         self.zoom = 0.2
         self.camera_x = ship.x
         self.camera_y = ship.y
@@ -517,6 +525,20 @@ class HyperJumpMap:
         for sector in self.sectors:
             sector.draw(screen, off_x, off_y, self.zoom)
 
+        for obj in self.objects:
+            if hasattr(obj, "draw_at"):
+                obj.draw_at(screen, off_x, off_y, self.zoom)
+            elif hasattr(obj, "ship") and hasattr(obj.ship, "draw_at"):
+                obj.ship.draw_at(screen, off_x, off_y, self.zoom)
+            elif hasattr(obj, "draw"):
+                try:
+                    obj.draw(screen, off_x, off_y, self.zoom)
+                except TypeError:
+                    try:
+                        obj.draw(screen, None, off_x, off_y, self.zoom)
+                    except Exception:
+                        pass
+
         ship_pos = (
             int((self.ship.x - off_x) * self.zoom),
             int((self.ship.y - off_y) * self.zoom),
@@ -543,11 +565,19 @@ class HyperJumpMap:
 class CarrierMoveMap:
     """Interactive map for moving a carrier via autopilot."""
 
-    def __init__(self, carrier, sectors, world_w: int, world_h: int) -> None:
+    def __init__(
+        self,
+        carrier,
+        sectors,
+        world_w: int,
+        world_h: int,
+        objects: list | None = None,
+    ) -> None:
         self.carrier = carrier
         self.sectors = sectors
         self.world_w = world_w
         self.world_h = world_h
+        self.objects = objects or []
         self.zoom = 0.2
         self.camera_x = carrier.x
         self.camera_y = carrier.y
@@ -596,6 +626,20 @@ class CarrierMoveMap:
         off_y = self.camera_y - config.WINDOW_HEIGHT / (2 * self.zoom)
         for sector in self.sectors:
             sector.draw(screen, off_x, off_y, self.zoom)
+
+        for obj in self.objects:
+            if hasattr(obj, "draw_at"):
+                obj.draw_at(screen, off_x, off_y, self.zoom)
+            elif hasattr(obj, "ship") and hasattr(obj.ship, "draw_at"):
+                obj.ship.draw_at(screen, off_x, off_y, self.zoom)
+            elif hasattr(obj, "draw"):
+                try:
+                    obj.draw(screen, off_x, off_y, self.zoom)
+                except TypeError:
+                    try:
+                        obj.draw(screen, None, off_x, off_y, self.zoom)
+                    except Exception:
+                        pass
 
         carrier_pos = (
             int((self.carrier.x - off_x) * self.zoom),


### PR DESCRIPTION
## Summary
- show optional objects on `HyperJumpMap` and `CarrierMoveMap`
- pass active ships and structures when opening the maps

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `SDL_VIDEODRIVER=dummy python src/main.py` *(interrupted after start)*

------
https://chatgpt.com/codex/tasks/task_e_686b4d90015883319c64d6f4261b5848