### PR TITLE
Enable allied ships to follow player

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -169,6 +169,8 @@ def main():
         )
         for _ in range(2)
     ]
+    for ally in friendly_ships:
+        ally.start_autopilot(ship)
     inventory_window = None
     market_window = None
     weapon_menu = None
@@ -615,6 +617,8 @@ def main():
             structures,
         )
         for ally in friendly_ships:
+            if ally.autopilot_target is None:
+                ally.start_autopilot(ship)
             ally.update(
                 _NullKeys(),
                 dt,


### PR DESCRIPTION
## Summary
- make allied ships start autopilot when spawned
- ensure allies keep following the player's ship during updates

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686b504cb4a883319523471b146165da