### PR TITLE
Fix LearningAlly projectile drawing

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -738,7 +738,7 @@ def main():
             aura_color=player.fraction.color if player.fraction else None,
         )
         for ally in friendly_ships:
-            ally.draw_projectiles(screen, offset_x, offset_y, zoom)
+            ally.ship.draw_projectiles(screen, offset_x, offset_y, zoom)
         for enemy in enemies:
             enemy.ship.draw_projectiles(screen, offset_x, offset_y, zoom)
         ship.draw_projectiles(screen, offset_x, offset_y, zoom)


### PR DESCRIPTION
## Summary
- call `draw_projectiles` on `LearningAlly`'s ship

## Testing
- `python -m py_compile src/main.py`
- `python -m py_compile src/ally_learning.py src/enemy_learning.py src/enemy.py`

------
https://chatgpt.com/codex/tasks/task_e_686b54aed2f88331a834d5ac0cbff6b6