### PR TITLE
Fix ally loading crash and prevent friendly fire

### DIFF
--- a/src/ally_learning.py
+++ b/src/ally_learning.py
@@ -121,6 +121,9 @@ class LearningAlly(LearningEnemy):
             self.player_prev_hull = self.player_ship.hull
         state = self._state(hostiles or [])
         action = self.choose_action(state)
+        if action == "attack" and threat is None:
+            # Don't fire on the player when no hostile target is present
+            action = "pursue"
         self.perform_action(action)
         self.ship.update(
             _NullKeys(),

--- a/src/main.py
+++ b/src/main.py
@@ -393,10 +393,13 @@ def main():
                     wy = event.pos[1] / zoom + offset_y
                     target = None
                     for ally in friendly_ships:
-                        if math.hypot(ally.x - wx, ally.y - wy) <= ally.collision_radius:
+                        if (
+                            math.hypot(ally.ship.x - wx, ally.ship.y - wy)
+                            <= ally.ship.collision_radius
+                        ):
                             target = ally
                             break
-                    if target and carrier.load_ship(target):
+                    if target and carrier.load_ship(target.ship):
                         friendly_ships.remove(target)
                     load_mode = False
                 continue


### PR DESCRIPTION
## Summary
- fix attribute access when loading allies into the carrier
- stop allies from attacking the player when no threat is nearby

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686c0c90a0cc83319e325ec23de18a34