### PR TITLE
Add ally reward metrics

### DIFF
--- a/src/ally_metrics.py
+++ b/src/ally_metrics.py
@@ -1,0 +1,25 @@
+import csv
+from pathlib import Path
+from typing import Iterable, Tuple
+
+
+def save_reward_history(history: Iterable[Tuple[float, float]], path: str = "ally_reward_history.csv") -> None:
+    """Save accumulated reward over time to a CSV file.
+
+    Parameters
+    ----------
+    history:
+        Iterable of ``(time, reward)`` pairs.
+    path:
+        Destination CSV path. Created if it does not exist.
+    """
+    data = list(history)
+    if not data:
+        return
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["time", "reward"])
+        writer.writerows(data)
+


### PR DESCRIPTION
## Summary
- track LearningAlly reward over time
- add new `ally_metrics` module to store reward history in CSV
- record reward history while updating and save to CSV when Q-table is saved

## Testing
- `python -m py_compile src/ally_metrics.py src/ally_learning.py`
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686c3145186483319c544f8d4ea0dc79