### PR TITLE
Implement fading ship exhaust particles

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -47,7 +47,8 @@ BOOST_RECHARGE = 10.0   # seconds to fully recharge boost
 # Particle effects for ship thrusters
 SHIP_PARTICLE_MAX = 80         # maximum number of exhaust particles
 SHIP_PARTICLE_DURATION = 0.6   # lifetime of each exhaust particle in seconds
-SHIP_PARTICLE_COLOR = (255, 160, 80)
+# Exhaust particles fade from a neutral gray tone
+SHIP_PARTICLE_COLOR = (180, 180, 180)
 
 # Camera speed when planning a route
 CAMERA_PAN_SPEED = 500  # pixels per second

--- a/src/ship.py
+++ b/src/ship.py
@@ -57,6 +57,8 @@ class _ShipParticle:
         self.vy = vy
         self.color = config.SHIP_PARTICLE_COLOR
         self.lifetime = config.SHIP_PARTICLE_DURATION
+        # Store starting lifetime so we can fade the particle out over time
+        self.max_life = config.SHIP_PARTICLE_DURATION
 
     def update(self, dt: float) -> None:
         self.x += self.vx * dt
@@ -741,7 +743,12 @@ class Ship:
         for p in self.particles:
             px = int((p.x - offset_x) * zoom)
             py = int((p.y - offset_y) * zoom)
-            pygame.draw.circle(screen, p.color, (px, py), max(1, int(2 * zoom)))
+            # Fade out by scaling alpha with remaining life
+            alpha = max(0.0, min(1.0, p.lifetime / p.max_life))
+            radius = max(1, int(2 * alpha * zoom))
+            surface = pygame.Surface((radius * 2, radius * 2), pygame.SRCALPHA)
+            pygame.draw.circle(surface, p.color + (int(alpha * 255),), (radius, radius), radius)
+            screen.blit(surface, (px - radius, py - radius))
 
     def draw_at(
         self,


### PR DESCRIPTION
## Summary
- add gray tone for ship thruster particles
- track particle start lifetime so we can fade them out
- draw exhaust particles with alpha that shrinks and fades

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_686c5a9eb9048331a12bf371c67afbbf