### PR TITLE
Improve hyperjump visuals and orientation

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -99,6 +99,10 @@ HYPERJUMP_VIGNETTE_ALPHA = 220
 # Minimum and maximum duration of hyperjump animations in seconds
 HYPERJUMP_MIN_TIME = 1.0
 HYPERJUMP_MAX_TIME = 60.0
+# Appearance of the trail shown during a hyperjump
+HYPERJUMP_TRAIL_WIDTH = 12
+HYPERJUMP_TRAIL_COLOR = (80, 150, 255)
+HYPERJUMP_TRAIL_INNER_COLOR = (255, 255, 255)
 # --- Defensive drone settings -------------------------------------------------
 # Standard orbit radius is based on the owner's size
 DEF_DRONE_ORBIT_RADIUS_FACTOR = 3.0


### PR DESCRIPTION
## Summary
- orient ship toward destination when a hyperjump starts
- render a large blue/white trail while jumping
- expose new hyperjump trail appearance settings

## Testing
- `python -m py_compile src/ship.py`
- `python -m py_compile src/config.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_686c5d33acc483319b5e65f6b6ecd538