### PR TITLE
Add hyperjump shock effect and fading trail

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -103,6 +103,8 @@ HYPERJUMP_MAX_TIME = 60.0
 HYPERJUMP_TRAIL_WIDTH = 12
 HYPERJUMP_TRAIL_COLOR = (80, 150, 255)
 HYPERJUMP_TRAIL_INNER_COLOR = (255, 255, 255)
+# Color of the brief shock effect when entering hyperspace
+HYPERJUMP_SHOCK_COLOR = (255, 120, 50)
 # --- Defensive drone settings -------------------------------------------------
 # Standard orbit radius is based on the owner's size
 DEF_DRONE_ORBIT_RADIUS_FACTOR = 3.0


### PR DESCRIPTION
## Summary
- fade hyperjump trail as the jump progresses
- draw a short shock cone when the ship enters hyperspace
- configure shock color

## Testing
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686c5f1658d4833192e39108fb482327