### PR TITLE
Reduce Pirate bomb detection range

### DIFF
--- a/src/faction_structures.py
+++ b/src/faction_structures.py
@@ -407,7 +407,7 @@ class CapitalShip(FactionStructure):
                     if (
                         not proj.exploded
                         and math.hypot(proj.x - en.ship.x, proj.y - en.ship.y)
-                        <= proj.radius
+                        <= proj.radius * 0.8
                     ):
                         proj.explode()
                 if proj.exploded:


### PR DESCRIPTION
## Summary
- reduce detection radius when Pirate Clans bombs check for nearby targets

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c7610380083319568effc2545a676