### PR TITLE
Add Explorer portals and teleport

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -76,6 +76,12 @@ WORMHOLE_DELAY = 5.0         # seconds before teleport occurs
 WORMHOLE_COOLDOWN = 3.0      # delay after teleport before re-entry allowed
 WORMHOLE_FLASH_TIME = 0.75   # duration of post-teleport flash effect
 
+# Portal settings used by the Free Explorers flagship
+PORTAL_RADIUS = 15
+PORTAL_COLOR = (0, 255, 0)
+PORTAL_COST = 10            # credits required to use when not a Free Explorer
+PORTAL_COOLDOWN = 1.0       # delay after teleport before re-entry allowed
+
 
 # Speed multiplier applied to all computer controlled ships and drones
 # Use the same speed factor for all ships so they travel evenly

--- a/src/portal.py
+++ b/src/portal.py
@@ -1,0 +1,53 @@
+import pygame
+import random
+import math
+import config
+
+class Portal:
+    """Simple teleportation gate that links to another portal."""
+
+    def __init__(self, x: float, y: float, radius: int | None = None) -> None:
+        self.x = x
+        self.y = y
+        self.radius = radius if radius is not None else config.PORTAL_RADIUS
+        self.color = config.PORTAL_COLOR
+        self.pair: "Portal" | None = None
+
+    def set_pair(self, other: "Portal") -> None:
+        self.pair = other
+        other.pair = self
+
+    def draw(
+        self,
+        screen: pygame.Surface,
+        offset_x: float = 0.0,
+        offset_y: float = 0.0,
+        zoom: float = 1.0,
+    ) -> None:
+        scaled = max(1, int(self.radius * zoom))
+        center = (
+            int((self.x - offset_x) * zoom),
+            int((self.y - offset_y) * zoom),
+        )
+        pygame.draw.circle(screen, self.color, center, scaled, 1)
+        if scaled > 2:
+            pygame.draw.circle(screen, self.color, center, scaled // 2, 1)
+
+
+def spawn_explorer_portals(free_ship, world_width: int, world_height: int) -> list[Portal]:
+    """Create three paired portals around ``free_ship`` and across the world."""
+    portals: list[Portal] = []
+    for _ in range(3):
+        ang = random.uniform(0, math.tau)
+        dist = random.uniform(60, 90)
+        near = Portal(
+            free_ship.x + math.cos(ang) * dist,
+            free_ship.y + math.sin(ang) * dist,
+        )
+        far = Portal(
+            random.randint(0, world_width),
+            random.randint(0, world_height),
+        )
+        near.set_pair(far)
+        portals.extend([near, far])
+    return portals


### PR DESCRIPTION
## Summary
- create new `Portal` object and utility to spawn pairs
- define portal parameters in `config`
- spawn portals near the Free Explorers flagship
- teleport player when colliding with portals (credits cost for outsiders)
- render portals in the main loop

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686c7e3c35c08331b913b22f001cd4fe