### PR TITLE
Fix NameError in drone target selection

### DIFF
--- a/src/combat.py
+++ b/src/combat.py
@@ -466,7 +466,7 @@ class BombDrone:
             d = math.hypot(obj.ship.x - self.x, obj.ship.y - self.y)
             if d < min_d:
                 min_d = d
-                nearest = en
+                nearest = obj
         return nearest
 
     def _explode(self) -> None:
@@ -572,7 +572,7 @@ class Drone:
             d = math.hypot(obj.ship.x - self.x, obj.ship.y - self.y)
             if d < min_d:
                 min_d = d
-                nearest = en
+                nearest = obj
         return nearest
 
     def expired(self) -> bool:


### PR DESCRIPTION
## Summary
- correct variable name when assigning nearest target for drones

## Testing
- `python -m py_compile src/combat.py`


------
https://chatgpt.com/codex/tasks/task_e_686c855012dc8331a274945116bb6490