### PR TITLE
Move Free Explorers turrets closer to hull edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,9 @@ faction's fleet.
 ### Free Explorers flagship and portals
 
 The Free Explorers capital ship now appears as a round gray disk with a black
-edge and a neutral gray aura. Four missile turrets are mounted at the cardinal
-points. These launch homing missiles that deal 20% extra damage but travel 20%
+edge and a neutral gray aura. Four missile turrets sit near the extreme north,
+south, east and west edges of the hull so they are spaced farther apart. These
+launch homing missiles that deal 20% extra damage but travel 20%
 slower than standard versions. Each missile detonates after a short lifetime,
 producing a very small blast radius.
 

--- a/src/faction_structures.py
+++ b/src/faction_structures.py
@@ -348,9 +348,14 @@ class CapitalShip(FactionStructure):
             self.modules.extend(["Survey Deck", "Jump Drives"])
             self.color = (160, 160, 160)
             self.outline_color = (0, 0, 0)
+            # Slightly enlarge the hull so turrets can sit farther apart
+            self.radius = 70
+            self.size = self.radius
             self.shape = "round"
+            # Position missile turrets near the outer edge but still inside
+            turret_dist = self.radius - 5
             self.turrets = [
-                MissileTurret(self, i * (math.pi / 2), self.radius)
+                MissileTurret(self, i * (math.pi / 2), turret_dist)
                 for i in range(4)
             ]
 


### PR DESCRIPTION
## Summary
- enlarge the Free Explorers flagship so its missile turrets can be farther apart
- keep turrets within the hull by placing them just inside the edge
- document the new turret placement in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_686c8b22dfd48331a6c1abde01e5f441