### PR TITLE
Fix VS Code extra paths

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
     "python.analysis.extraPaths": [
-        "./vastvoid/entities",
-        "./vastvoid"
+        "./src"
     ]
 }


### PR DESCRIPTION
## Summary
- fix nonexistent `python.analysis.extraPaths`

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_686c9602cc288331a49351f410242cb3