### PR TITLE
Fix route line and ship drawing to use camera offset

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -742,7 +742,7 @@ def main():
                 player.fraction,
                 player.fraction.color if player.fraction else None,
             )
-        ship.draw(screen, zoom, player.fraction)
+        ship.draw_at(screen, offset_x, offset_y, zoom, player.fraction)
         route_planner.draw(screen, info_font, ship, offset_x, offset_y, zoom)
 
         if selected_object:

--- a/src/ui.py
+++ b/src/ui.py
@@ -95,8 +95,8 @@ class RoutePlanner:
     ) -> None:
         if self.destination:
             start = (
-                config.WINDOW_WIDTH // 2,
-                config.WINDOW_HEIGHT // 2,
+                int((ship.x - offset_x) * zoom),
+                int((ship.y - offset_y) * zoom),
             )
             end = (
                 int((self.destination.x - offset_x) * zoom),


### PR DESCRIPTION
## Summary
- draw player ship using camera offset
- draw route planner line from the ship's screen position

## Testing
- `python -m py_compile src/main.py src/ui.py`
- `python src/main.py` *(fails: XDG_RUNTIME_DIR invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686c99c8ca1c8331a20d0ae063586682