### PR TITLE
Add Common Berthing Mechanism and crew transfers

### DIFF
--- a/src/cbm.py
+++ b/src/cbm.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+from crew import CrewMember
+
+if TYPE_CHECKING:
+    from ship import Ship
+
+
+class CommonBerthingMechanism:
+    """Simple docking mechanism allowing two ships to connect."""
+
+    def __init__(self, host: Ship, range: float = 40.0) -> None:
+        self.host = host
+        self.range = range
+        self.docked_to: Ship | None = None
+
+    def can_dock(self, other_ship: Ship) -> bool:
+        """Return ``True`` if ``other_ship`` is within docking range."""
+        if self.docked_to is not None:
+            return False
+        distance = math.hypot(self.host.x - other_ship.x, self.host.y - other_ship.y)
+        limit = self.range + self.host.collision_radius + other_ship.collision_radius
+        return distance <= limit
+
+    def dock(self, other_ship: Ship) -> bool:
+        """Dock ``other_ship`` if within range."""
+        if not self.can_dock(other_ship):
+            return False
+        self.docked_to = other_ship
+        if getattr(other_ship, "cbm", None):
+            other_ship.cbm.docked_to = self.host
+        self.host.vx = self.host.vy = 0.0
+        return True
+
+    def undock(self) -> None:
+        """Separate from any currently docked ship."""
+        if self.docked_to and getattr(self.docked_to, "cbm", None):
+            self.docked_to.cbm.docked_to = None
+        self.docked_to = None
+
+    def transfer_to_docked(self, member: CrewMember) -> bool:
+        """Move ``member`` from the host ship to the docked ship."""
+        if not self.docked_to:
+            return False
+        if member not in self.host.passengers:
+            return False
+        self.host.passengers.remove(member)
+        self.docked_to.passengers.append(member)
+        return True
+
+    def transfer_from_docked(self, member: CrewMember) -> bool:
+        """Move ``member`` from the docked ship back to the host."""
+        if not self.docked_to:
+            return False
+        if member not in self.docked_to.passengers:
+            return False
+        self.docked_to.passengers.remove(member)
+        self.host.passengers.append(member)
+        return True
+
+__all__ = ["CommonBerthingMechanism"]

--- a/src/crew.py
+++ b/src/crew.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+@dataclass
+class CrewMember:
+    """Simple data container representing a crew member."""
+
+    name: str
+    role: str = "Passenger"
+
+__all__ = ["CrewMember"]

--- a/src/ship.py
+++ b/src/ship.py
@@ -3,6 +3,8 @@ import math
 from dataclasses import dataclass
 import config
 from fraction import Fraction
+from crew import CrewMember
+from cbm import CommonBerthingMechanism
 from planet import Planet
 from names import get_ship_name
 from combat import (
@@ -79,6 +81,7 @@ class Ship:
         hull: int = 100,
         speed_factor: float = 1.0,
         fraction: Fraction | None = None,
+        has_cbm: bool = False,
     ) -> None:
         self.x = float(x)
         self.y = float(y)
@@ -136,10 +139,26 @@ class Ship:
         # Collision radius for the triangular hull
         height = self.size * 1.5
         self.collision_radius = math.hypot(height / 2, self.size / 2)
+        self.passengers: list[CrewMember] = []
+        self.cbm: CommonBerthingMechanism | None = (
+            CommonBerthingMechanism(self) if has_cbm else None
+        )
 
     def set_active_weapon(self, index: int) -> None:
         if 0 <= index < len(self.weapons):
             self.active_weapon = index
+
+    def transfer_crew_to_docked(self, member: CrewMember) -> bool:
+        """Move ``member`` to the ship currently docked with this one."""
+        if self.cbm:
+            return self.cbm.transfer_to_docked(member)
+        return False
+
+    def transfer_crew_from_docked(self, member: CrewMember) -> bool:
+        """Retrieve ``member`` from the ship currently docked with this one."""
+        if self.cbm:
+            return self.cbm.transfer_from_docked(member)
+        return False
 
     def update(
         self,


### PR DESCRIPTION
## Summary
- implement `CrewMember` dataclass
- create `CommonBerthingMechanism` with docking/transfer functions
- extend `Ship` with optional CBM support and passenger handling

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686d4df7295c833184d464df714394df