### PR TITLE
Fix docking attr error

### DIFF
--- a/src/faction_structures.py
+++ b/src/faction_structures.py
@@ -264,6 +264,11 @@ class CapitalShip(FactionStructure):
     engagement_ring: EngagementRing | None = None
     city_stations: list[Any] = field(default_factory=list)
 
+    @property
+    def collision_radius(self) -> float:
+        """Return the effective collision radius for this ship."""
+        return max(self.radius, self.aura_radius)
+
     def apply_fraction_traits(self, fraction: Fraction) -> None:
         super().apply_fraction_traits(fraction)
         # Default size is tied to the collision radius so dependent systems


### PR DESCRIPTION
## Summary
- expose collision radius for capital ships

## Testing
- `python -m py_compile src/faction_structures.py`
- `python - <<'EOF'
import sys
sys.path.append('src')
from cbm import CommonBerthingMechanism
from ship import Ship, ShipModel
from faction_structures import CapitalShip
from fraction import FRACTIONS
player_ship = Ship(0, 0, ShipModel('Fighter','Brand',18,(1,1,1)))
player_ship.cbm = CommonBerthingMechanism(player_ship)
cap = CapitalShip('Flagship')
cap.apply_fraction_traits(FRACTIONS[0])
print('collision radius', cap.collision_radius)
print('can dock', player_ship.cbm.can_dock(cap))
EOF

------
https://chatgpt.com/codex/tasks/task_e_686d6800d794833182fa9232cf1dc8fd