### PR TITLE
Fix pilot setup for player's ship

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -134,6 +134,7 @@ def main():
         fraction=player.fraction,
         speed_factor=config.NPC_SPEED_FACTOR,
     )
+    ship.assign_pilot(player)
     ship.weapons.extend([
         LaserWeapon(),
         MineWeapon(),


### PR DESCRIPTION
## Summary
- assign the player as the pilot when their ship is created

## Testing
- `pip install -r requirements.txt`
- `SDL_VIDEODRIVER=dummy python src/main.py` *(fails: awaiting input)*

------
https://chatgpt.com/codex/tasks/task_e_686d81dbd1508331ae8223e8b1206cd5