### PR TITLE
Fix losing previous ship when switching control

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -228,6 +228,10 @@ def main():
                 active_ship = candidate
                 break
         if active_ship and active_ship is not ship:
+            if ship not in extra_ships and ship is not carrier:
+                extra_ships.append(ship)
+            if active_ship in extra_ships:
+                extra_ships.remove(active_ship)
             ship = active_ship
             ability_bar.set_ship(ship)
             if weapon_menu:


### PR DESCRIPTION
## Summary
- handle switching active ship so previous vessel remains in the world

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d717170c0833185a36f4f8eaac743