### PR TITLE
Fix spores weapon aiming

### DIFF
--- a/src/combat.py
+++ b/src/combat.py
@@ -910,7 +910,7 @@ class SporesWeapon(Weapon):
         if not self.can_fire():
             return None
         self._timer = 0.0
-        angle = self.owner.angle
+        angle = math.atan2(ty - y, tx - x)
         dist = self.owner.size * 2
         sx = self.owner.x + math.cos(angle) * dist
         sy = self.owner.y + math.sin(angle) * dist


### PR DESCRIPTION
## Summary
- use math.atan2 in `SporesWeapon.fire`
- spawn the spore cloud from the ship nose using that angle

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686da22f1d3c8331a5ef93236df3bec3