### PR TITLE
Increase spore weapon range

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ button to return to space.
 * The flagship also fields defensive drones that orbit the vessel and intercept
   nearby threats.
 * Ships can deploy a **Chrono Tachionic Whip** that slows enemies within a small field.
-* A new **Spores** weapon releases a short-lived damaging cloud.
+* A new **Spores** weapon releases a damaging cloud that lasts four seconds and
+  reaches 30% farther.
 * Charge the **Ionized Symbiont** to fire a shot that latches onto enemy hulls and inflicts damage over time.
 
 ### Defensive drones
@@ -52,7 +53,8 @@ The game offers three distinctive special weapons:
   recharge. While it is on cooldown, the whip fires weaker shots 10% faster with
   slightly reduced projectile speed.
 * **Spores** – fires a cone-shaped cloud in front of the ship that damages foes
-  for three seconds. This weapon can be used once every five seconds.
+  for four seconds and extends 30% farther. This weapon can be used once every
+  five seconds.
 
 ## Character creation
 

--- a/src/combat.py
+++ b/src/combat.py
@@ -830,9 +830,9 @@ class SporeCloud:
         x: float,
         y: float,
         angle: float,
-        radius: float = 144.0,
+        radius: float = 187.2,
         arc: float = math.pi / 3,
-        duration: float = 3.0,
+        duration: float = 4.0,
         damage: float = 6.0,
     ) -> None:
         self.owner = owner


### PR DESCRIPTION
## Summary
- extend SporeCloud duration from 3 to 4 seconds
- increase its radius by 30%
- document longer range and duration in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686da9ebae0c8331a99632b91dc27a87