### PR TITLE
Improve spore cloud visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ button to return to space.
 * The flagship also fields defensive drones that orbit the vessel and intercept
   nearby threats.
 * Ships can deploy a **Chrono Tachionic Whip** that slows enemies within a small field.
-* A new **Spores** weapon releases a damaging cloud that lasts four seconds and
-  reaches 30% farther.
+* A new **Spores** weapon releases a damaging cloud that lasts four seconds,
+  reaches 30% farther and now spreads over a wider cone. The spores stay in
+  place until they fade and each particle is 15% larger for better visibility.
 * Charge the **Ionized Symbiont** to fire a shot that latches onto enemy hulls and inflicts damage over time.
 
 ### Defensive drones
@@ -52,9 +53,10 @@ The game offers three distinctive special weapons:
   ability is ready. The field lasts five seconds and requires 10 seconds to
   recharge. While it is on cooldown, the whip fires weaker shots 10% faster with
   slightly reduced projectile speed.
-* **Spores** – fires a cone-shaped cloud in front of the ship that damages foes
-  for four seconds and extends 30% farther. This weapon can be used once every
-  five seconds.
+* **Spores** – fires a wider cone-shaped cloud in front of the ship that
+  damages foes for four seconds and extends 30% farther. The spores remain in
+  place until the effect ends and are 15% larger. This weapon can be used once
+  every five seconds.
 
 ## Character creation
 

--- a/src/combat.py
+++ b/src/combat.py
@@ -803,12 +803,11 @@ class _SporeParticle:
 
     def __init__(self, cloud) -> None:
         ang = cloud.angle + random.uniform(-cloud.arc / 2, cloud.arc / 2)
-        max_speed = cloud.radius / cloud.duration
-        speed = random.uniform(max_speed * 0.5, max_speed)
-        self.vx = math.cos(ang) * speed
-        self.vy = math.sin(ang) * speed
-        self.x = cloud.x
-        self.y = cloud.y
+        dist = random.uniform(0, cloud.radius)
+        self.x = cloud.x + math.cos(ang) * dist
+        self.y = cloud.y + math.sin(ang) * dist
+        self.vx = 0.0
+        self.vy = 0.0
         self.max_life = cloud.duration
         self.life = self.max_life
 
@@ -831,7 +830,7 @@ class SporeCloud:
         y: float,
         angle: float,
         radius: float = 220.0,
-        arc: float = math.pi / 3,
+        arc: float = math.pi / 2,
         duration: float = 7.0,
         damage: float = 6.0,
     ) -> None:
@@ -886,9 +885,11 @@ class SporeCloud:
             px = int((p.x - offset_x) * zoom)
             py = int((p.y - offset_y) * zoom)
             alpha = max(0, min(255, int(p.life / p.max_life * 255)))
-            surf = pygame.Surface((3, 3), pygame.SRCALPHA)
-            pygame.draw.circle(surf, (120, 200, 120, alpha), (1, 1), 1)
-            screen.blit(surf, (px - 1, py - 1))
+            size = int(math.ceil(3 * 1.15))
+            radius = int(math.ceil(1 * 1.15))
+            surf = pygame.Surface((size, size), pygame.SRCALPHA)
+            pygame.draw.circle(surf, (120, 200, 120, alpha), (size // 2, size // 2), radius)
+            screen.blit(surf, (px - size // 2, py - size // 2))
 
 
 class SporesWeapon(Weapon):


### PR DESCRIPTION
## Summary
- spawn spores at random positions inside the cloud and keep them stationary
- widen the spore cloud cone
- enlarge each spore particle
- document the updated Spores weapon behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686db5a6e1bc833197cc511f45a222a3