### PR TITLE
Shorten spore cloud radius

### DIFF
--- a/src/combat.py
+++ b/src/combat.py
@@ -842,7 +842,9 @@ class SporeCloud:
         x: float,
         y: float,
         angle: float,
-        radius: float = 220.0,
+        # Reduced radius to make the isosceles triangle of the spore cloud
+        # 20% shorter, resulting in a tighter damage cone.
+        radius: float = 176.0,
         arc: float = math.pi * 0.4,
         duration: float = 7.0,
         damage: float = 6.0,


### PR DESCRIPTION
## Summary
- shorten spore cloud damage area radius by 20%

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686db93b6b2c8331bddef096f0e2594b