### PR TITLE
Add mouse wheel zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ button to return to space.
 ## Features
 
 * Land on planets to explore procedurally generated surfaces.
+* Zoom in and out using the mouse wheel.
 * Travel instantly via wormholes linking distant sectors.
 * Engage hyper-speed travel to jump across the map
   (one-second charge with an eight-second cooldown).

--- a/src/main.py
+++ b/src/main.py
@@ -552,11 +552,7 @@ def main():
                     continue
 
             if event.type == pygame.KEYDOWN:
-                if event.key == pygame.K_q:
-                    zoom = max(0.1, zoom - 0.1)
-                elif event.key == pygame.K_e:
-                    zoom += 0.1
-                elif event.key == pygame.K_ESCAPE:
+                if event.key == pygame.K_ESCAPE:
                     selected_object = None
                 elif event.key == pygame.K_i:
                     inventory_window = InventoryWindow(player)
@@ -588,7 +584,15 @@ def main():
                     tx = mx / zoom + offset_x
                     ty = my / zoom + offset_y
                     ship.release_weapon_charge(tx, ty)
+            elif event.type == pygame.MOUSEWHEEL:
+                zoom = max(0.1, zoom + event.y * 0.1)
             elif event.type == pygame.MOUSEBUTTONDOWN:
+                if event.button == 4:
+                    zoom += 0.1
+                    continue
+                elif event.button == 5:
+                    zoom = max(0.1, zoom - 0.1)
+                    continue
                 offset_x = camera_x - config.WINDOW_WIDTH / (2 * zoom)
                 offset_y = camera_y - config.WINDOW_HEIGHT / (2 * zoom)
                 world_x = event.pos[0] / zoom + offset_x


### PR DESCRIPTION
## Summary
- enable mouse wheel scrolling to control zoom
- drop Q/E zoom bindings
- document zoom controls in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_686de2809a6c83319fd3275bf9358096