### PR TITLE
Add Ajustes settings window

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,3 +196,5 @@ Lista de controles predeterminados para las acciones principales:
 | Mover cámara en planificador | Flechas del teclado |
 | Activar/desactivar bote | B |
 
+Puedes consultar esta misma lista durante la partida desde la opción **Ajustes** del menú principal.
+

--- a/src/main.py
+++ b/src/main.py
@@ -29,6 +29,7 @@ from ui import (
     AbilityBar,
     WeaponMenu,
     ArtifactMenu,
+    SettingsWindow,
     HyperJumpMap,
     CarrierMoveMap,
     CarrierWindow,
@@ -171,7 +172,13 @@ def main():
     zoom = 1.0
     selected_object = None
     info_font = pygame.font.Font(None, 20)
-    menu = DropdownMenu(10, 10, 100, 25, ["Plan Route", "Inventory", "Weapons", "Artifacts"])
+    menu = DropdownMenu(
+        10,
+        10,
+        100,
+        25,
+        ["Plan Route", "Inventory", "Weapons", "Artifacts", "Ajustes"],
+    )
     route_planner = RoutePlanner()
     ability_bar = AbilityBar()
     ability_bar.set_ship(ship)
@@ -183,6 +190,7 @@ def main():
     market_window = None
     weapon_menu = None
     artifact_menu = None
+    settings_window = None
     carrier_window = None
     current_station = None
     current_surface = None
@@ -327,6 +335,19 @@ def main():
                     break
             if artifact_menu:
                 artifact_menu.draw(screen, info_font)
+                pygame.display.flip()
+                continue
+
+        if settings_window:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    running = False
+                    break
+                if settings_window.handle_event(event):
+                    settings_window = None
+                    break
+            if settings_window:
+                settings_window.draw(screen, info_font)
                 pygame.display.flip()
                 continue
 
@@ -507,6 +528,8 @@ def main():
                 weapon_menu = WeaponMenu(ship)
             elif selection == "Artifacts":
                 artifact_menu = ArtifactMenu(ship, ability_bar)
+            elif selection == "Ajustes":
+                settings_window = SettingsWindow()
 
             route_planner.handle_event(event, sectors, (camera_x, camera_y), zoom)
             if ability_bar.handle_event(event, ship):

--- a/src/ui.py
+++ b/src/ui.py
@@ -4,6 +4,26 @@ import math
 import types
 from artifact import Artifact
 
+# Default key bindings for common actions. These match the table in the README
+# so they can be displayed in the in-game Ajustes/Settings window.
+DEFAULT_CONTROLS = [
+    ("Mover nave o explorador", "W, A, S, D"),
+    ("Impulso (boost)", "Mantener LSHIFT"),
+    ("Abrir inventario", "I"),
+    ("Abrir menú de armas", "F"),
+    ("Abrir menú de artefactos", "G"),
+    ("Abrir mercado en estación", "M"),
+    ("Iniciar acoplamiento", "C"),
+    ("Cargar nave aliada en portador", "L"),
+    ("Disparar arma principal", "Barra espaciadora"),
+    ("Seleccionar/interactuar", "Clic izquierdo"),
+    ("Cerrar ventana o cancelar", "Escape"),
+    ("Cambiar zoom", "Rueda del ratón"),
+    ("Elegir ranura (al equipar)", "1, 2 o 3"),
+    ("Mover cámara en planificador", "Flechas del teclado"),
+    ("Activar/desactivar bote", "B"),
+]
+
 class DropdownMenu:
     """Simple dropdown menu triggered by a button."""
 
@@ -359,6 +379,40 @@ class ArtifactMenu:
 
         # Draw current ability bar so the player knows which slot to replace
         self.ability_bar.draw(screen, font)
+
+
+class SettingsWindow:
+    """Display the default control bindings."""
+
+    def __init__(self) -> None:
+        self.close_rect = pygame.Rect(config.WINDOW_WIDTH - 110, 10, 100, 30)
+
+    def handle_event(self, event) -> bool:
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            if self.close_rect.collidepoint(event.pos):
+                return True
+        if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+            return True
+        return False
+
+    def draw(self, screen: pygame.Surface, font: pygame.font.Font) -> None:
+        screen.fill((20, 20, 40))
+        title = font.render("Ajustes", True, (255, 255, 255))
+        screen.blit(title, (20, 20))
+
+        x0, y0 = 20, 60
+        row_h = 20
+        col_x = 320
+        for i, (action, key) in enumerate(DEFAULT_CONTROLS):
+            action_txt = font.render(action, True, (255, 255, 255))
+            key_txt = font.render(key, True, (255, 255, 255))
+            screen.blit(action_txt, (x0, y0 + i * row_h))
+            screen.blit(key_txt, (col_x, y0 + i * row_h))
+
+        pygame.draw.rect(screen, (60, 60, 90), self.close_rect)
+        pygame.draw.rect(screen, (200, 200, 200), self.close_rect, 1)
+        txt = font.render("Close", True, (255, 255, 255))
+        screen.blit(txt, txt.get_rect(center=self.close_rect.center))
 
 
 class AbilityBar:


### PR DESCRIPTION
## Summary
- add default control bindings table in `ui` for easy access
- implement `SettingsWindow` to show controls
- include `Ajustes` option in dropdown menu with a new event loop
- expose settings window in README with instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686de643cc208331b5e9ec99ca0456a4