### PR TITLE
Add LightChannelerWeapon to default weapon loadout

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -15,6 +15,7 @@ from combat import (
     ChronoTachionicWhip,
     SporesWeapon,
 )
+from light_channeler import LightChannelerWeapon
 from sector import create_sectors
 from fraction import FRACTIONS
 from faction_structures import spawn_capital_ships
@@ -150,6 +151,7 @@ def main():
         IonizedSymbiontWeapon(),
         ChronoTachionicWhip(),
         SporesWeapon(),
+        LightChannelerWeapon(),
         BasicWeapon(),
     ])
     for w in ship.weapons:


### PR DESCRIPTION
## Summary
- include `LightChannelerWeapon` import in `main.py`
- add the weapon to the player's default list

## Testing
- `python -m py_compile src/main.py src/ui.py src/light_channeler.py`

------
https://chatgpt.com/codex/tasks/task_e_686ec9a0cdd48331aa7dcbb43e3384d1