### PR TITLE
Improve LightChannelerWeapon

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,3 +1,5 @@
+import math
+
 WINDOW_WIDTH, WINDOW_HEIGHT = 800, 600
 BACKGROUND_COLOR = (0, 0, 20)  # near black
 
@@ -147,3 +149,12 @@ STAR_TURRET_DISCONNECTED_LOSS = 1.0
 CADENCE_100_RPM = 60.0 / 100.0
 # Seconds between shots for a cadence of 30 rounds per minute
 CADENCE_30_RPM = 60.0 / 30.0
+
+# Deployment timing for LightChannelerWeapon components
+CHANNELER_BATTERY_DELAY = 2.0  # seconds before the battery becomes visible
+CHANNELER_TURRET_DELAY = 5.0   # seconds before the turret activates
+
+# Firing parameters for the star turret
+STAR_TURRET_ARC = math.pi * 0.1
+STAR_TURRET_PROJECTILE_SPEED = 380
+STAR_TURRET_PROJECTILE_DAMAGE = 6


### PR DESCRIPTION
## Summary
- add math import and constants for the light channeler
- randomize star turret firing direction and use regular projectiles
- show channeler assembly over 5 seconds with deploy delays

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686ed77f99e88331a5d48af505e3a0ca