### PR TITLE
Limit star turret projectile range

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -158,3 +158,5 @@ CHANNELER_TURRET_DELAY = 5.0   # seconds before the turret activates
 STAR_TURRET_ARC = math.pi * 0.1
 STAR_TURRET_PROJECTILE_SPEED = 380
 STAR_TURRET_PROJECTILE_DAMAGE = 6
+# Maximum distance for star turret projectiles (30% shorter than default)
+STAR_TURRET_PROJECTILE_MAX_DISTANCE = PROJECTILE_MAX_DISTANCE * 0.7

--- a/src/light_channeler.py
+++ b/src/light_channeler.py
@@ -147,6 +147,7 @@ class StarTurret:
                 self.y + math.sin(ang),
                 config.STAR_TURRET_PROJECTILE_SPEED,
                 config.STAR_TURRET_PROJECTILE_DAMAGE,
+                max_distance=config.STAR_TURRET_PROJECTILE_MAX_DISTANCE,
             )
             self.projectiles.append(proj)
         for proj in list(self.projectiles):


### PR DESCRIPTION
## Summary
- add STAR_TURRET_PROJECTILE_MAX_DISTANCE constant set to 70% of normal projectile range
- use this distance for LightChanneler turret projectiles

## Testing
- `python -m py_compile src/light_channeler.py src/config.py`


------
https://chatgpt.com/codex/tasks/task_e_686eda2c1f4c8331bd5aa13c3ca133aa