### PR TITLE
Add zoom mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Lista de controles predeterminados para las acciones principales:
 | Disparar arma principal | Barra espaciadora |
 | Seleccionar/interactuar | Clic izquierdo |
 | Cerrar ventana o cancelar | Escape |
-| Cambiar zoom | Rueda del ratón |
+| Cambiar zoom | Rueda del ratón o Q/E |
 | Elegir ranura (al equipar) | 1, 2 o 3 |
 | Mover cámara en planificador | Flechas del teclado |
 | Activar/desactivar bote | B |
@@ -209,4 +209,6 @@ Puedes consultar esta misma lista durante la partida desde la opción **Ajustes*
 Las preferencias de teclado se guardan en `saves/controls.json`. Abre dicho
 menú, haz clic en una acción y pulsa la nueva tecla para actualizarla. Los
 cambios se escriben de inmediato y estarán disponibles en la siguiente sesión.
+La misma ventana incluye un conmutador para elegir si el zoom se controla con
+la rueda del ratón o con las teclas **Q** y **E**.
 

--- a/src/game_settings.py
+++ b/src/game_settings.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+
+# Default settings
+DEFAULT_SETTINGS = {
+    "zoom_with_wheel": True,
+}
+
+SETTINGS = DEFAULT_SETTINGS.copy()
+
+_FILE_PATH = Path(__file__).resolve().parent.parent / "saves" / "settings.json"
+
+
+def load_settings() -> None:
+    """Load settings from ``saves/settings.json`` if present."""
+    global SETTINGS
+    if _FILE_PATH.exists():
+        try:
+            data = json.loads(_FILE_PATH.read_text())
+        except Exception:
+            return
+        for name, value in data.items():
+            if name in DEFAULT_SETTINGS:
+                SETTINGS[name] = bool(value)
+    else:
+        SETTINGS = DEFAULT_SETTINGS.copy()
+
+
+def save_settings() -> None:
+    """Persist settings to ``saves/settings.json``."""
+    _FILE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _FILE_PATH.write_text(json.dumps(SETTINGS, indent=2))
+
+
+def get_setting(name: str):
+    """Return the current value of ``name`` from SETTINGS."""
+    return SETTINGS.get(name, DEFAULT_SETTINGS.get(name))
+
+
+def set_setting(name: str, value) -> None:
+    """Update ``name`` with ``value``."""
+    SETTINGS[name] = value

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@ import math
 import random
 import config
 import control_settings as controls
+import game_settings as settings
 from ship import Ship, choose_ship
 from carrier import Carrier
 from combat import (
@@ -108,6 +109,7 @@ def main():
     screen = pygame.display.set_mode((config.WINDOW_WIDTH, config.WINDOW_HEIGHT))
     pygame.display.set_caption("VastVoid")
     controls.load_bindings()
+    settings.load_settings()
     vignette = _create_vignette(config.WINDOW_WIDTH, config.WINDOW_HEIGHT)
 
     player = choose_player_table(screen)
@@ -611,15 +613,21 @@ def main():
                     tx = mx / zoom + offset_x
                     ty = my / zoom + offset_y
                     ship.release_weapon_charge(tx, ty)
-            elif event.type == pygame.MOUSEWHEEL:
+            elif event.type == pygame.MOUSEWHEEL and settings.get_setting("zoom_with_wheel"):
                 zoom = max(0.1, zoom + event.y * 0.1)
-            elif event.type == pygame.MOUSEBUTTONDOWN:
-                if event.button == 4:
+            elif event.type == pygame.KEYDOWN and not settings.get_setting("zoom_with_wheel"):
+                if event.key == pygame.K_e:
                     zoom += 0.1
-                    continue
-                elif event.button == 5:
+                elif event.key == pygame.K_q:
                     zoom = max(0.1, zoom - 0.1)
-                    continue
+            elif event.type == pygame.MOUSEBUTTONDOWN:
+                if settings.get_setting("zoom_with_wheel"):
+                    if event.button == 4:
+                        zoom += 0.1
+                        continue
+                    elif event.button == 5:
+                        zoom = max(0.1, zoom - 0.1)
+                        continue
                 offset_x = camera_x - config.WINDOW_WIDTH / (2 * zoom)
                 offset_y = camera_y - config.WINDOW_HEIGHT / (2 * zoom)
                 world_x = event.pos[0] / zoom + offset_x

--- a/src/ui.py
+++ b/src/ui.py
@@ -1,6 +1,7 @@
 import pygame
 import config
 import control_settings as controls
+import game_settings as settings
 import math
 import types
 from artifact import Artifact
@@ -390,6 +391,7 @@ class SettingsWindow:
         self.actions = list(controls.DEFAULT_BINDINGS.keys())
         self.editing: str | None = None
         self.row_rects: list[pygame.Rect] = []
+        self.zoom_rect = pygame.Rect(0, 0, 0, 0)
 
     def handle_event(self, event) -> bool:
         if self.editing:
@@ -406,6 +408,11 @@ class SettingsWindow:
                 if rect.collidepoint(event.pos):
                     self.editing = action
                     break
+            if self.zoom_rect.collidepoint(event.pos):
+                current = settings.get_setting("zoom_with_wheel")
+                settings.set_setting("zoom_with_wheel", not current)
+                settings.save_settings()
+                return False
         if event.type == pygame.KEYDOWN and event.key == controls.get_key("cancel"):
             return True
         return False
@@ -430,6 +437,13 @@ class SettingsWindow:
             key_txt = font.render(keyname, True, (255, 255, 255))
             screen.blit(action_txt, (x0 + 5, y0 + i * row_h))
             screen.blit(key_txt, (col_x, y0 + i * row_h))
+
+        zoom_y = y0 + len(self.actions) * row_h + 10
+        self.zoom_rect = pygame.Rect(x0, zoom_y, col_x - x0 - 10, row_h)
+        pygame.draw.rect(screen, (60, 60, 90), self.zoom_rect)
+        mode = "Rueda" if settings.get_setting("zoom_with_wheel") else "Q/E"
+        zoom_txt = font.render(f"Zoom: {mode}", True, (255, 255, 255))
+        screen.blit(zoom_txt, (x0 + 5, zoom_y))
 
         pygame.draw.rect(screen, (60, 60, 90), self.close_rect)
         pygame.draw.rect(screen, (200, 200, 200), self.close_rect, 1)


### PR DESCRIPTION
## Summary
- create `game_settings` to store persistent settings
- allow toggling zoom control method in settings window
- update main loop to honor zoom setting
- document the new option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686f082cb7cc8331b75abc9c9f94b346