### PR TITLE
Fix player listing to exclude config files

### DIFF
--- a/src/savegame.py
+++ b/src/savegame.py
@@ -76,7 +76,7 @@ def list_players() -> List[str]:
         return []
     names = []
     for fname in os.listdir(SAVE_DIR):
-        if fname.endswith(".json"):
+        if fname.endswith(".json") and fname not in {"controls.json", "settings.json"}:
             names.append(os.path.splitext(fname)[0])
     return sorted(names)
 


### PR DESCRIPTION
## Summary
- ensure `list_players` ignores `controls.json` and `settings.json`

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686f0febb3e88331aef4b0a0c785c167