### PR TITLE
Implement click-to-move autopilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Lista de controles predeterminados para las acciones principales:
 | Iniciar acoplamiento | C |
 | Cargar nave aliada en portador | L |
 | Disparar arma principal | Barra espaciadora |
-| Seleccionar/interactuar | Clic izquierdo |
+| Seleccionar/interactuar (o mover nave en punto vacío) | Clic izquierdo |
 | Cerrar ventana o cancelar | Escape |
 | Cambiar zoom | Rueda del ratón o Q/E |
 | Elegir ranura (al equipar) | 1, 2 o 3 |

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 import pygame
 import math
 import random
+import types
 import config
 import control_settings as controls
 import game_settings as settings
@@ -673,6 +674,8 @@ def main():
                         if math.hypot(carrier.x - world_x, carrier.y - world_y) <= carrier.collision_radius:
                             carrier_window = CarrierWindow(carrier)
                             continue
+                        dest = types.SimpleNamespace(x=world_x, y=world_y)
+                        ship.start_autopilot(dest)
                 elif event.button == 3:
                     camera_dragging = True
                     camera_last = event.pos

--- a/src/ui.py
+++ b/src/ui.py
@@ -18,7 +18,7 @@ DEFAULT_CONTROLS = [
     ("Iniciar acoplamiento", "C"),
     ("Cargar nave aliada en portador", "L"),
     ("Disparar arma principal", "Barra espaciadora"),
-    ("Seleccionar/interactuar", "Clic izquierdo"),
+    ("Seleccionar/interactuar o mover nave", "Clic izquierdo"),
     ("Cerrar ventana o cancelar", "Escape"),
     ("Cambiar zoom", "Rueda del ratón"),
     ("Elegir ranura (al equipar)", "1, 2 o 3"),


### PR DESCRIPTION
## Summary
- allow moving the ship by left clicking on empty space
- document the click-to-move control in README and UI defaults

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686f1e90e6e88331a9f764572568e93d