### PR TITLE
Fix click-move autopilot speed

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -15,7 +15,7 @@ BOUNCE_FACTOR = 1.0
 # Maximum travel speed for manual control
 SHIP_MAX_SPEED = 100
 # Slightly slower autopilot speed to keep movement moderate
-AUTOPILOT_SPEED = 100  # pixels per second when auto moving
+AUTOPILOT_SPEED = 80  # pixels per second when auto moving
 PLANET_LANDING_SPEED = 80  # slower speed when approaching a planet
 
 # --- Hull settings -----------------------------------------------------------


### PR DESCRIPTION
## Summary
- slow down autopilot so click-to-move travels at a normal pace

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686f1d3e4c708331883292d880d75d0d