### PR TITLE
Add detailed stats to ship models

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -141,7 +141,6 @@ def main():
         world_width // 2,
         world_height // 2,
         chosen_model,
-        hull=config.PLAYER_MAX_HULL,
         fraction=player.fraction,
         speed_factor=config.NPC_SPEED_FACTOR,
     )
@@ -171,7 +170,6 @@ def main():
         ship.x + 350,
         ship.y,
         chosen_model,
-        hull=config.PLAYER_MAX_HULL,
         fraction=player.fraction,
         speed_factor=config.NPC_SPEED_FACTOR,
     )
@@ -972,7 +970,7 @@ def main():
         hull_y = shield_y - 15
         pygame.draw.rect(screen, (60, 60, 90), (bar_x, hull_y, bar_width, bar_height))
         pygame.draw.rect(screen, (200, 200, 200), (bar_x, hull_y, bar_width, bar_height), 1)
-        hull_fill = int(bar_width * ship.hull / config.PLAYER_MAX_HULL)
+        hull_fill = int(bar_width * ship.hull / ship.max_hull)
         if hull_fill > 0:
             pygame.draw.rect(screen, (150, 0, 0), (bar_x, hull_y, hull_fill, bar_height))
         weapon = ship.weapons[ship.active_weapon]


### PR DESCRIPTION
## Summary
- extend `ShipModel` dataclass with hull, shield, default weapons and special ability
- populate `SHIP_MODELS` with the new values
- apply model stats when instantiating ships
- display hull bar based on a ship's own max hull
- create ships without passing a manual hull value

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68743c4efc808331b22eff31a8365cc3