### PR TITLE
Use noise for biome generation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 pygame
 numpy
 
+# 2D Perlin noise for terrain generation
+noise
+
 # Optional dependencies for advanced features:


### PR DESCRIPTION
## Summary
- add `noise` dependency for perlin noise
- generate map biomes using 2D noise instead of expansion

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68744dc20b948331810bff3bb27b4ca2