### PR TITLE
Add patch scale to biome patches

### DIFF
--- a/src/biome.py
+++ b/src/biome.py
@@ -7,6 +7,7 @@ class Biome:
     color: tuple[int, int, int]
     spawn_items: List[str]
     spawn_rate: float  # probability [0,1] of item spawn per patch
+    patch_scale: float = 1.0
 
 
 BIOMES: dict[str, Biome] = {
@@ -15,35 +16,41 @@ BIOMES: dict[str, Biome] = {
         (50, 120, 50),
         ["flor eterea", "pluma de fenix", "gema de alma"],
         0.15,
+        1.2,
     ),
     # Arid landscapes rich in ancient artefacts
     "desert": Biome(
         (210, 200, 150),
         ["arena del tiempo", "fragmento de meteorito", "mapa estelar antiguo"],
         0.15,
+        1.0,
     ),
     # Frozen plains with valuable energy sources
     "ice world": Biome(
         (220, 235, 245),
         ["helio-3", "cristal quantico", "huevo de dragon"],
         0.15,
+        1.0,
     ),
     # Volcanic regions containing rare minerals
     "lava": Biome(
         (150, 60, 30),
         ["plutonio", "antimateria", "corazon de estrella"],
         0.1,
+        0.8,
     ),
     # Deep oceans with strange curiosities
     "ocean world": Biome(
         (30, 80, 160),
         ["hidrogeno liquido", "vapor condensado", "lagrima de sirena"],
         0.15,
+        1.3,
     ),
     # Default rocky surfaces
     "rocky": Biome(
         (110, 110, 110),
         ["hierro", "cobre", "cuarzo"],
         0.12,
+        0.9,
     ),
 }

--- a/src/planet_surface.py
+++ b/src/planet_surface.py
@@ -148,8 +148,8 @@ class PlanetSurface:
         """Draw a more organic looking patch of terrain."""
         # Randomly choose between an ellipse or an irregular polygon
         if random.random() < 0.5:
-            w = random.randint(40, 120)
-            h = random.randint(30, 80)
+            w = int(random.randint(40, 120) * biome.patch_scale)
+            h = int(random.randint(30, 80) * biome.patch_scale)
             x = random.randint(rect.left, rect.right)
             y = random.randint(rect.top, rect.bottom)
             shape = pygame.Rect(x - w // 2, y - h // 2, w, h)
@@ -251,7 +251,7 @@ class PlanetSurface:
             self.planet.biomes if self.planet.biomes else [self.planet.environment]
         )
         biomes = [
-            BIOMES.get(name, Biome(ENV_COLORS.get(name, (90, 90, 90)), [], 0))
+            BIOMES.get(name, Biome(ENV_COLORS.get(name, (90, 90, 90)), [], 0, 1.0))
             for name in biome_names
         ]
 


### PR DESCRIPTION
## Summary
- extend `Biome` dataclass with `patch_scale`
- configure `patch_scale` for default biomes
- scale ellipse width/height in patch drawing
- handle new argument when creating fallback `Biome`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687451348df48331860d3eb60d4b531a