### PR TITLE
Handle missing noise dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,20 @@ classification category.
 Saved profiles are presented in a simple table when the game launches.
 Each row lists the player's name alongside **Load** and **Delete** buttons,
 and a separate *New Profile* button lets you create a fresh character.
+
 New profiles are saved automatically once created so they appear on the list
 the next time you run the game.
+
+## Installation
+
+Install the dependencies listed in `requirements.txt`:
+
+```bash
+pip install -r requirements.txt
+```
+
+Planet terrain generation relies on the `noise` package. If it is missing the
+game will raise an error explaining how to install it.
 
 ## Running the game
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pygame
 numpy
 
-# 2D Perlin noise for terrain generation
+# 2D Perlin noise for terrain generation (required)
 noise
 
 # Optional dependencies for advanced features:

--- a/src/planet_surface.py
+++ b/src/planet_surface.py
@@ -1,7 +1,13 @@
 import math
 import pygame
 import random
-import noise
+try:
+    import noise
+except ImportError as exc:
+    raise RuntimeError(
+        "The 'noise' package is required. "
+        "Run 'pip install noise' or install all requirements."
+    ) from exc
 import config
 import control_settings as controls
 from biome import BIOMES, Biome


### PR DESCRIPTION
## Summary
- guard `import noise` with a helpful runtime error
- document how to install dependencies
- note that the noise library is required in requirements.txt

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687487d696848331943b73e1504460bc