### PR TITLE
Fix drone orbit angle after intercept

### DIFF
--- a/src/aggressive_defensive_drone.py
+++ b/src/aggressive_defensive_drone.py
@@ -35,11 +35,13 @@ class AggressiveDefensiveDrone(Drone):
         self.target = None
 
     def update(self, dt: float, targets: list) -> None:
-        """Intercept nearby threats while shooting rapidly."""
+        """Intercept nearby threats while keeping orbital phase."""
 
         self.lifetime -= dt
+        # Keep moving along the orbit even when intercepting
+        self.angle = (self.angle + self.orbit_speed * dt) % (2 * math.pi)
+
         if self.state == "idle":
-            self.angle += self.orbit_speed * dt
             self.x = self.owner.x + math.cos(self.angle) * self.radius
             self.y = self.owner.y + math.sin(self.angle) * self.radius
             threat = self._find_target(targets)

--- a/src/defensive_drone.py
+++ b/src/defensive_drone.py
@@ -42,8 +42,11 @@ class DefensiveDrone:
         return None
 
     def update(self, dt: float, objects: list) -> None:
+        """Update the drone state while preserving its orbit angle."""
+        # Advance the orbit angle even when intercepting so spacing is kept
+        self.angle = (self.angle + self.orbit_speed * dt) % (2 * math.pi)
+
         if self.state == "idle":
-            self.angle += self.orbit_speed * dt
             self.x = self.owner.x + math.cos(self.angle) * self.orbit_radius
             self.y = self.owner.y + math.sin(self.angle) * self.orbit_radius
             threat = self._find_threat(objects)


### PR DESCRIPTION
## Summary
- keep orbit phase for defensive drones even when intercepting
- apply to both basic and aggressive drone variants

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68757d9eceb88331bb479a37bee2a23a