### PR TITLE
Add research manager persistence

### DIFF
--- a/src/character.py
+++ b/src/character.py
@@ -2,6 +2,7 @@ import pygame
 import config
 from fraction import FRACTIONS, Fraction
 from items import ITEMS_BY_NAME
+from tech_tree import ResearchManager
 
 class Alien:
     """Basic Alien species."""
@@ -29,6 +30,7 @@ class Player:
         fraction: Fraction,
         ship_model=None,
         credits: int = 0,
+        research: ResearchManager | None = None,
     ):
         self.name = name
         self.age = age
@@ -38,6 +40,8 @@ class Player:
         self.credits = credits
         # Inventory starts empty but contains an entry for each known item
         self.inventory: dict[str, int] = {name: 0 for name in ITEMS_BY_NAME}
+        # Research manager to track tech progress
+        self.research: ResearchManager = research or ResearchManager()
 
     def add_item(self, item: str, quantity: int = 1) -> None:
         """Add `quantity` of `item` to the inventory."""

--- a/tests/test_savegame_research.py
+++ b/tests/test_savegame_research.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+import savegame
+from character import Player, Human
+from fraction import FRACTIONS
+from tech_tree import ResearchManager, TECH_TREE
+
+
+def test_save_and_load_research(tmp_path):
+    savegame.SAVE_DIR = str(tmp_path)
+
+    mgr = ResearchManager()
+    mgr.start("mining")
+    mgr.advance(TECH_TREE["mining"].cost)
+    mgr.start("advanced_energy")
+    mgr.advance(50)
+
+    player = Player("Test", 25, Human(), FRACTIONS[0], research=mgr)
+    savegame.save_player(player)
+
+    loaded = savegame.load_player("Test")
+    assert loaded.research.completed == mgr.completed
+    assert loaded.research.in_progress == mgr.in_progress


### PR DESCRIPTION
## Summary
- track player's research progress in Player
- persist ResearchManager state in savegame JSON
- load persisted research when loading a player
- add regression test for save/load of ResearchManager

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68758b37dee483318b1aacb9eed51c1e