### PR TITLE
Implement research bonus for PlanetOutpost

### DIFF
--- a/src/faction_structures.py
+++ b/src/faction_structures.py
@@ -12,6 +12,7 @@ from aggressive_defensive_drone import AggressiveDefensiveDrone
 from station import SpaceStation
 import pygame
 import config
+from tech_tree import ResearchManager
 
 
 @dataclass
@@ -831,10 +832,23 @@ class PlanetOutpost(FactionStructure):
     """Small base used to claim planets or moons."""
 
     capacity: int = 10
+    research_bonus: float = 0.0
 
-    def apply_fraction_traits(self, fraction: Fraction) -> None:
+    def apply_fraction_traits(
+        self,
+        fraction: Fraction,
+        research: "ResearchManager | None" = None,
+        facilities: list[str] | None = None,
+    ) -> None:
         super().apply_fraction_traits(fraction)
-        # Future implementation may provide research or trade perks.
+        facilities = facilities or []
+        self.research_bonus = 0.0
+
+        if research and "deep_space" in research.completed:
+            self.research_bonus += 0.1
+
+        if "Research Labs" in facilities:
+            self.research_bonus += 0.1
 
 
 def spawn_capital_ships(

--- a/tests/test_faction_structures.py
+++ b/tests/test_faction_structures.py
@@ -4,8 +4,9 @@ from pathlib import Path
 # Ensure src is on the Python path
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
-from faction_structures import CapitalShip, verify_pirate_turret_positions
+from faction_structures import CapitalShip, PlanetOutpost, verify_pirate_turret_positions
 from fraction import FRACTIONS
+from tech_tree import ResearchManager
 
 
 def test_verify_pirate_turret_positions():
@@ -13,4 +14,23 @@ def test_verify_pirate_turret_positions():
     ship = CapitalShip(name="Pirate Flagship")
     ship.apply_fraction_traits(pirate_fraction)
     assert verify_pirate_turret_positions(ship) is True
+
+
+def test_outpost_research_bonus():
+    nebula_fraction = next(f for f in FRACTIONS if f.name == "Nebula Order")
+    outpost = PlanetOutpost(name="Test Outpost")
+    mgr = ResearchManager()
+
+    # Bonus from facilities only
+    outpost.apply_fraction_traits(nebula_fraction, research=mgr, facilities=["Research Labs"])
+    assert outpost.research_bonus == 0.1
+
+    # Bonus from completed technology
+    mgr.completed.add("deep_space")
+    outpost.apply_fraction_traits(nebula_fraction, research=mgr)
+    assert outpost.research_bonus == 0.1
+
+    # Combined bonuses
+    outpost.apply_fraction_traits(nebula_fraction, research=mgr, facilities=["Research Labs"])
+    assert outpost.research_bonus == 0.2
 


### PR DESCRIPTION
## Summary
- give PlanetOutpost a `research_bonus` attribute
- provide optional arguments to apply the bonus based on completed tech and built facilities
- test the new behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68758c9ea2988331a7412857122d038b