### PR TITLE
Add click-to-move toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ menú, haz clic en una acción y pulsa la nueva tecla para actualizarla. Los
 cambios se escriben de inmediato y estarán disponibles en la siguiente sesión.
 La misma ventana incluye un conmutador para elegir si el zoom se controla con
 la rueda del ratón o con las teclas **Q** y **E**.
+También permite activar o desactivar que la nave se mueva al hacer clic con el ratón.
 
 
 ## License

--- a/saves/settings.json
+++ b/saves/settings.json
@@ -1,3 +1,4 @@
 {
-  "zoom_with_wheel": false
+  "zoom_with_wheel": false,
+  "click_to_move": true
 }

--- a/src/game_settings.py
+++ b/src/game_settings.py
@@ -4,6 +4,7 @@ from pathlib import Path
 # Default settings
 DEFAULT_SETTINGS = {
     "zoom_with_wheel": True,
+    "click_to_move": True,
 }
 
 SETTINGS = DEFAULT_SETTINGS.copy()

--- a/src/main.py
+++ b/src/main.py
@@ -672,8 +672,9 @@ def main():
                         if math.hypot(carrier.x - world_x, carrier.y - world_y) <= carrier.collision_radius:
                             carrier_window = CarrierWindow(carrier)
                             continue
-                        dest = types.SimpleNamespace(x=world_x, y=world_y)
-                        ship.start_autopilot(dest)
+                        if settings.get_setting("click_to_move"):
+                            dest = types.SimpleNamespace(x=world_x, y=world_y)
+                            ship.start_autopilot(dest)
                 elif event.button == 3:
                     camera_dragging = True
                     camera_last = event.pos

--- a/src/ui.py
+++ b/src/ui.py
@@ -392,6 +392,7 @@ class SettingsWindow:
         self.editing: str | None = None
         self.row_rects: list[pygame.Rect] = []
         self.zoom_rect = pygame.Rect(0, 0, 0, 0)
+        self.click_rect = pygame.Rect(0, 0, 0, 0)
 
     def handle_event(self, event) -> bool:
         if self.editing:
@@ -411,6 +412,11 @@ class SettingsWindow:
             if self.zoom_rect.collidepoint(event.pos):
                 current = settings.get_setting("zoom_with_wheel")
                 settings.set_setting("zoom_with_wheel", not current)
+                settings.save_settings()
+                return False
+            if self.click_rect.collidepoint(event.pos):
+                current = settings.get_setting("click_to_move")
+                settings.set_setting("click_to_move", not current)
                 settings.save_settings()
                 return False
         if event.type == pygame.KEYDOWN and event.key == controls.get_key("cancel"):
@@ -444,6 +450,14 @@ class SettingsWindow:
         mode = "Rueda" if settings.get_setting("zoom_with_wheel") else "Q/E"
         zoom_txt = font.render(f"Zoom: {mode}", True, (255, 255, 255))
         screen.blit(zoom_txt, (x0 + 5, zoom_y))
+
+        click_y = zoom_y + row_h + 5
+        self.click_rect = pygame.Rect(x0, click_y, col_x - x0 - 10, row_h)
+        pygame.draw.rect(screen, (60, 60, 90), self.click_rect)
+        enabled = settings.get_setting("click_to_move")
+        click_label = "Sí" if enabled else "No"
+        click_txt = font.render(f"Mover con clics: {click_label}", True, (255, 255, 255))
+        screen.blit(click_txt, (x0 + 5, click_y))
 
         pygame.draw.rect(screen, (60, 60, 90), self.close_rect)
         pygame.draw.rect(screen, (200, 200, 200), self.close_rect, 1)


### PR DESCRIPTION
## Summary
- allow toggling ship movement with mouse clicks via `click_to_move` setting
- expose new setting in the Ajustes window
- document the new option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687591e649408331b89da24ea7ebf5dc