### PR TITLE
Default click to move disabled

### DIFF
--- a/saves/settings.json
+++ b/saves/settings.json
@@ -1,4 +1,5 @@
 {
   "zoom_with_wheel": false,
-  "click_to_move": true
+  "click_to_move": false
 }
+

--- a/src/game_settings.py
+++ b/src/game_settings.py
@@ -4,7 +4,7 @@ from pathlib import Path
 # Default settings
 DEFAULT_SETTINGS = {
     "zoom_with_wheel": True,
-    "click_to_move": True,
+    "click_to_move": False,
 }
 
 SETTINGS = DEFAULT_SETTINGS.copy()


### PR DESCRIPTION
## Summary
- disable click-to-move in default game settings
- update the example settings file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687593b35ce48331931f0a8e9411ab4a