### PR TITLE
Integrate research tree window

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Each ship has a single pilot seat and two passenger slots. Press **C** when two 
 ## Árbol de investigación
 
 Ejecuta `python src/tech_ui.py` para abrir la interfaz que muestra las tecnologías disponibles.
+Ahora también puedes acceder al árbol durante la partida seleccionando **Research** en el menú desplegable del juego.
 Cada nodo indica los requisitos y el coste necesario para investigar. Al seleccionar un nodo con el ratón se despliega una breve descripción y, si todos los prerequisitos se cumplen, aparece el botón **Start**. Al pulsarlo el progreso aumenta con el tiempo hasta completar la investigación.
 
 Las tecnologías terminadas otorgan mejoras permanentes, como escudos de energía o el hiperpropulsor, y ciertas estructuras reciben bonificaciones si determinados avances ya están completados. Por ello, avanzar en el árbol amplía tus opciones durante la partida.

--- a/src/main.py
+++ b/src/main.py
@@ -38,6 +38,7 @@ from ui import (
     CarrierMoveMap,
     CarrierWindow,
     CrewTransferWindow,
+    ResearchWindow,
     draw_labeled_bar,
 )
 from cbm import CommonBerthingMechanism
@@ -182,7 +183,7 @@ def main():
         10,
         100,
         25,
-        ["Plan Route", "Inventory", "Weapons", "Artifacts", "Ajustes"],
+        ["Plan Route", "Inventory", "Weapons", "Artifacts", "Research", "Ajustes"],
     )
     route_planner = RoutePlanner()
     ability_bar = AbilityBar()
@@ -197,6 +198,7 @@ def main():
     artifact_menu = None
     settings_window = None
     carrier_window = None
+    research_window = None
     current_station = None
     current_surface = None
     approaching_planet = None
@@ -340,6 +342,20 @@ def main():
                     break
             if artifact_menu:
                 artifact_menu.draw(screen, info_font)
+                pygame.display.flip()
+                continue
+
+        if research_window:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    running = False
+                    break
+                if research_window.handle_event(event):
+                    research_window = None
+                    break
+            if research_window:
+                research_window.manager.advance(dt * 20)
+                research_window.draw(screen, info_font)
                 pygame.display.flip()
                 continue
 
@@ -533,6 +549,8 @@ def main():
                 weapon_menu = WeaponMenu(ship)
             elif selection == "Artifacts":
                 artifact_menu = ArtifactMenu(ship, ability_bar)
+            elif selection == "Research":
+                research_window = ResearchWindow(player.research)
             elif selection == "Ajustes":
                 settings_window = SettingsWindow()
 


### PR DESCRIPTION
## Summary
- add ResearchWindow class reusing tech_ui helpers
- hook research progress window into main game loop
- include "Research" item in the dropdown menu
- document new menu button in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687596ed97188331bec95d165c7d4630