### PR TITLE
Enable player features on research completion

### DIFF
--- a/src/character.py
+++ b/src/character.py
@@ -2,7 +2,7 @@ import pygame
 import config
 from fraction import FRACTIONS, Fraction
 from items import ITEMS_BY_NAME
-from tech_tree import ResearchManager
+from tech_tree import ResearchManager, TECH_TREE
 
 class Alien:
     """Basic Alien species."""
@@ -42,6 +42,8 @@ class Player:
         self.inventory: dict[str, int] = {name: 0 for name in ITEMS_BY_NAME}
         # Research manager to track tech progress
         self.research: ResearchManager = research or ResearchManager()
+        # Feature flags unlocked through research
+        self.features: set[str] = set()
 
     def add_item(self, item: str, quantity: int = 1) -> None:
         """Add `quantity` of `item` to the inventory."""
@@ -54,6 +56,15 @@ class Player:
         if item not in self.inventory:
             return
         self.inventory[item] = max(0, self.inventory[item] - quantity)
+
+    def progress_research(self, dt: float) -> list[str]:
+        """Advance research and unlock features for completed techs."""
+        finished = self.research.advance(dt)
+        for tid in finished:
+            node = TECH_TREE.get(tid)
+            if node:
+                self.features.update(node.unlocked_features)
+        return finished
 
 
 def create_player(screen: pygame.Surface) -> Player:

--- a/src/main.py
+++ b/src/main.py
@@ -354,7 +354,7 @@ def main():
                     research_window = None
                     break
             if research_window:
-                research_window.manager.advance(dt * 20)
+                player.progress_research(dt * 20)
                 research_window.draw(screen, info_font)
                 pygame.display.flip()
                 continue

--- a/tests/test_research_manager.py
+++ b/tests/test_research_manager.py
@@ -5,6 +5,8 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 from tech_tree import ResearchManager, TECH_TREE
+from character import Player, Human
+from fraction import FRACTIONS
 
 
 def test_can_start_respects_prerequisites():
@@ -33,3 +35,19 @@ def test_advance_completes_technology():
     assert "mining" in finished
     assert "mining" in mgr.completed
     assert "mining" not in mgr.in_progress
+
+
+def test_player_features_unlock_on_completion():
+    mgr = ResearchManager()
+    player = Player("Test", 30, Human(), FRACTIONS[0], research=mgr)
+
+    player.research.start("mining")
+    player.progress_research(TECH_TREE["mining"].cost)
+
+    player.research.start("advanced_energy")
+    # Halfway done should not unlock features
+    player.progress_research(TECH_TREE["advanced_energy"].cost / 2)
+    assert "Energy Shields" not in player.features
+
+    player.progress_research(TECH_TREE["advanced_energy"].cost / 2)
+    assert "Energy Shields" in player.features


### PR DESCRIPTION
## Summary
- extend `Player` with feature tracking and a method to progress research
- update main loop to use new progress helper
- unlock tech features when research completes
- test that tech completion enables the appropriate feature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68759bce844083318104fb9872f33671