### PR TITLE
Implement research bonus multiplier

### DIFF
--- a/src/character.py
+++ b/src/character.py
@@ -57,9 +57,9 @@ class Player:
             return
         self.inventory[item] = max(0, self.inventory[item] - quantity)
 
-    def progress_research(self, dt: float) -> list[str]:
-        """Advance research and unlock features for completed techs."""
-        finished = self.research.advance(dt)
+    def progress_research(self, dt: float, bonus: float = 1.0) -> list[str]:
+        """Advance research applying ``bonus`` and unlock completed techs."""
+        finished = self.research.advance(dt, bonus)
         for tid in finished:
             node = TECH_TREE.get(tid)
             if node:

--- a/src/main.py
+++ b/src/main.py
@@ -354,7 +354,17 @@ def main():
                     research_window = None
                     break
             if research_window:
-                player.progress_research(dt * 20)
+                # Gather structures to accumulate any research bonuses
+                structures = []
+                for cap in capital_ships:
+                    structures.append(cap)
+                    structures.extend(cap.city_stations)
+                structures.append(carrier)
+
+                bonus = 1.0
+                for s in structures:
+                    bonus += getattr(s, "research_bonus", 0.0)
+                player.progress_research(dt * 20, bonus)
                 research_window.draw(screen, info_font)
                 pygame.display.flip()
                 continue

--- a/src/tech_tree.py
+++ b/src/tech_tree.py
@@ -64,11 +64,11 @@ class ResearchManager:
             return True
         return False
 
-    def advance(self, dt: float) -> list[str]:
-        """Advance all ongoing research by ``dt`` points."""
+    def advance(self, dt: float, bonus: float = 1.0) -> list[str]:
+        """Advance all ongoing research by ``dt`` points applying ``bonus``."""
         finished: list[str] = []
         for tech_id in list(self.in_progress):
-            progress = self.in_progress[tech_id] + dt
+            progress = self.in_progress[tech_id] + dt * bonus
             cost = TECH_TREE[tech_id].cost
             if progress >= cost:
                 finished.append(tech_id)

--- a/tests/test_research_manager.py
+++ b/tests/test_research_manager.py
@@ -51,3 +51,13 @@ def test_player_features_unlock_on_completion():
 
     player.progress_research(TECH_TREE["advanced_energy"].cost / 2)
     assert "Energy Shields" in player.features
+
+
+def test_bonus_speeds_up_research():
+    mgr = ResearchManager()
+    mgr.start("mining")
+
+    # With a 2x bonus, half the cost should finish the tech
+    finished = mgr.advance(TECH_TREE["mining"].cost / 2, bonus=2.0)
+    assert "mining" in finished
+    assert "mining" in mgr.completed


### PR DESCRIPTION
## Summary
- allow ResearchManager.advance to speed up research via a bonus multiplier
- pass bonuses from surrounding structures in the main loop
- expose bonus parameter in Player.progress_research
- test that bonuses finish research faster

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68759da8fd44833181f976bdd16a7a86