### PR TITLE
Improve tech tree validation

### DIFF
--- a/tests/test_invalid_tree.py
+++ b/tests/test_invalid_tree.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+import tech_tree
+import tech_ui
+from tech_tree import TechNode, ResearchManager
+import pytest
+
+
+def test_cycle_detection(monkeypatch):
+    invalid = {
+        "a": TechNode("A", "", 0, ["b"], []),
+        "b": TechNode("B", "", 0, ["a"], []),
+    }
+    monkeypatch.setattr(tech_tree, "TECH_TREE", invalid)
+    monkeypatch.setattr(tech_ui, "TECH_TREE", invalid)
+    with pytest.raises(ValueError):
+        tech_ui._compute_levels()
+    mgr = ResearchManager()
+    with pytest.raises(ValueError):
+        mgr.can_start("a")


### PR DESCRIPTION
## Summary
- detect missing IDs and cycles when computing tech levels
- validate prerequisites inside `ResearchManager.can_start`
- test invalid tech tree handling

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68759edcf16883318f60b616ca3834ef