### PR TITLE
Check research before activating area shield

### DIFF
--- a/src/ship.py
+++ b/src/ship.py
@@ -24,6 +24,7 @@ from light_channeler import Channeler, Battery, StarTurret
 from artifact import (
     Artifact,
     AreaShieldAura,
+    AreaShieldArtifact,
     EMPWave,
     TractorProbe,
     RepairNanobots,
@@ -816,6 +817,11 @@ class Ship:
         """Activate an equipped artifact if possible."""
         if 0 <= index < len(self.artifacts):
             art = self.artifacts[index]
+            # Area shields depend on the Energy Shields research
+            if isinstance(art, AreaShieldArtifact):
+                pilot_feats = getattr(self.pilot, "features", set()) if self.pilot else set()
+                if "Energy Shields" not in pilot_feats:
+                    return
             if art.can_use():
                 art.activate(self, targets)
 

--- a/tests/test_ship_artifacts.py
+++ b/tests/test_ship_artifacts.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from ship import Ship
+from artifact import AreaShieldArtifact
+from character import Player, Human
+from fraction import FRACTIONS
+
+
+def test_area_shield_requires_research():
+    ship = Ship(0, 0)
+    player = Player("Test", 30, Human(), FRACTIONS[0])
+    ship.assign_pilot(player)
+    art = AreaShieldArtifact()
+    art._timer = art.cooldown
+    ship.artifacts = [art]
+
+    # Without Energy Shields feature
+    ship.use_artifact(0, [])
+    assert ship.area_shield is None
+
+    # Grant feature and try again
+    player.features.add("Energy Shields")
+    art._timer = art.cooldown
+    ship.use_artifact(0, [])
+    assert ship.area_shield is not None


### PR DESCRIPTION
## Summary
- allow area shield artifact only if the pilot has Energy Shields
- test that the artifact requires that research

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875ca6ac0748331928cc133a29186bb