### PR TITLE
Add admin developer profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ and a separate *New Profile* button lets you create a fresh character.
 New profiles are saved automatically once created so they appear on the list
 the next time you run the game.
 
+A special developer profile named **admin** is created automatically if it does
+not already exist. It includes all research, one unit of every item and plenty
+of credits so you can test the entire game without restrictions.
+
 ## Installation
 
 Install the dependencies listed in `requirements.txt`:

--- a/src/character.py
+++ b/src/character.py
@@ -152,11 +152,19 @@ def create_player(screen: pygame.Surface) -> Player:
 
 def choose_player(screen: pygame.Surface) -> Player:
     """Let the user pick an existing profile or create/delete one."""
-    from savegame import list_players, load_player, delete_player, save_player
+    from savegame import (
+        list_players,
+        load_player,
+        delete_player,
+        save_player,
+        ensure_admin_profile,
+    )
 
     font = pygame.font.Font(None, 32)
     clock = pygame.time.Clock()
     deleting = False
+    ensure_admin_profile()
+
     while True:
         profiles = list_players()
         for event in pygame.event.get():
@@ -197,13 +205,21 @@ def choose_player(screen: pygame.Surface) -> Player:
 
 def choose_player_table(screen: pygame.Surface) -> Player:
     """GUI with buttons to load or delete a profile."""
-    from savegame import list_players, load_player, delete_player, save_player
+    from savegame import (
+        list_players,
+        load_player,
+        delete_player,
+        save_player,
+        ensure_admin_profile,
+    )
 
     font = pygame.font.Font(None, 32)
     clock = pygame.time.Clock()
     name_w, btn_w, row_h = 200, 100, 40
     spacing = 10
     start_x, start_y = 50, 100
+
+    ensure_admin_profile()
 
     while True:
         profiles = list_players()

--- a/tests/test_admin_profile.py
+++ b/tests/test_admin_profile.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+import savegame
+from tech_tree import TECH_TREE
+
+
+def test_ensure_admin_profile(tmp_path):
+    savegame.SAVE_DIR = str(tmp_path)
+    savegame.ensure_admin_profile()
+
+    assert "admin" in savegame.list_players()
+
+    player = savegame.load_player("admin")
+    assert set(player.research.completed) == set(TECH_TREE)
+    assert all(qty == 1 for qty in player.inventory.values())
+
+    unlocked = set()
+    for node in TECH_TREE.values():
+        unlocked.update(node.unlocked_features)
+    assert unlocked.issubset(player.features)


### PR DESCRIPTION
## Summary
- automatically create a developer profile named `admin`
- regenerate feature flags when loading a player
- ensure the admin profile exists in the player selection menus
- document the new developer profile
- test admin profile creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875cee0d52c8331b184a2c32301b2b1