### PR TITLE
Add basic crafting system

### DIFF
--- a/src/character.py
+++ b/src/character.py
@@ -57,6 +57,17 @@ class Player:
             return
         self.inventory[item] = max(0, self.inventory[item] - quantity)
 
+    def craft_item(self, recipe: "Recipe") -> bool:
+        """Craft ``recipe.result`` consuming its ingredients if available."""
+        from crafting import can_craft
+
+        if not can_craft(self.inventory, recipe):
+            return False
+        for name, qty in recipe.ingredients.items():
+            self.remove_item(name, qty)
+        self.add_item(recipe.result, 1)
+        return True
+
     def progress_research(self, dt: float, bonus: float = 1.0) -> list[str]:
         """Advance research applying ``bonus`` and unlock completed techs."""
         finished = self.research.advance(dt, bonus)

--- a/src/crafting.py
+++ b/src/crafting.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from typing import Dict, List
+
+from items import ITEMS_BY_NAME
+
+
+@dataclass
+class Recipe:
+    """Simple crafting recipe."""
+
+    result: str
+    ingredients: Dict[str, int]
+
+    def validate(self) -> None:
+        if self.result not in ITEMS_BY_NAME:
+            raise ValueError(f"Unknown result item: {self.result}")
+        for name in self.ingredients:
+            if name not in ITEMS_BY_NAME:
+                raise ValueError(f"Unknown ingredient: {name}")
+
+
+RECIPES: List[Recipe] = [
+    Recipe("rifle de plasma", {"pistola laser": 1, "combustible ionico": 2}),
+    Recipe("lanzallamas", {"taladro": 1, "combustible de fusion": 1}),
+    Recipe(
+        "moto antigravitatoria",
+        {"buggy lunar": 1, "bateria portatil": 2, "pico laser": 1},
+    ),
+    Recipe("generador de escudo", {"bateria portatil": 2, "cortador laser": 1}),
+]
+
+for r in RECIPES:
+    r.validate()
+
+
+def can_craft(inventory: Dict[str, int], recipe: Recipe) -> bool:
+    """Return ``True`` if ``inventory`` has enough ingredients for ``recipe``."""
+    return all(inventory.get(name, 0) >= qty for name, qty in recipe.ingredients.items())

--- a/src/main.py
+++ b/src/main.py
@@ -29,6 +29,7 @@ from ui import (
     DropdownMenu,
     RoutePlanner,
     InventoryWindow,
+    CraftingWindow,
     MarketWindow,
     AbilityBar,
     WeaponMenu,
@@ -41,6 +42,7 @@ from ui import (
     ResearchWindow,
     draw_labeled_bar,
 )
+from crafting import RECIPES
 from cbm import CommonBerthingMechanism
 from artifact import (
     EMPArtifact,
@@ -204,6 +206,7 @@ def main():
     crew_window = None
     inventory_window = None
     market_window = None
+    crafting_window = None
     weapon_menu = None
     artifact_menu = None
     settings_window = None
@@ -281,7 +284,11 @@ def main():
                     break
                 if inventory_window:
                     if inventory_window.handle_event(event):
+                        open_craft = inventory_window.open_craft
                         inventory_window = None
+                        if open_craft:
+                            crafting_window = CraftingWindow(player, RECIPES)
+                        continue
                     continue
                 if event.type == pygame.KEYDOWN and event.key == controls.get_key("open_inventory"):
                     inventory_window = InventoryWindow(player)
@@ -322,10 +329,26 @@ def main():
                     running = False
                     break
                 if inventory_window.handle_event(event):
+                    open_craft = inventory_window.open_craft
                     inventory_window = None
+                    if open_craft:
+                        crafting_window = CraftingWindow(player, RECIPES)
                     break
             if inventory_window:
                 inventory_window.draw(screen, info_font)
+                pygame.display.flip()
+                continue
+
+        if crafting_window:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    running = False
+                    break
+                if crafting_window.handle_event(event):
+                    crafting_window = None
+                    break
+            if crafting_window:
+                crafting_window.draw(screen, info_font)
                 pygame.display.flip()
                 continue
 

--- a/tests/test_crafting.py
+++ b/tests/test_crafting.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+# Make src importable
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from crafting import RECIPES
+from character import Player, Human
+from fraction import FRACTIONS
+
+
+def test_craft_item_success():
+    player = Player("Test", 20, Human(), FRACTIONS[0])
+    recipe = RECIPES[0]
+    for name, qty in recipe.ingredients.items():
+        player.add_item(name, qty)
+    assert player.craft_item(recipe)
+    assert player.inventory[recipe.result] == 1
+    for name in recipe.ingredients:
+        assert player.inventory[name] == 0
+
+
+def test_craft_item_missing():
+    player = Player("Test", 20, Human(), FRACTIONS[0])
+    recipe = RECIPES[1]
+    # add only part of ingredients
+    for name, qty in list(recipe.ingredients.items())[:-1]:
+        player.add_item(name, qty)
+    assert not player.craft_item(recipe)
+    assert player.inventory[recipe.result] == 0


### PR DESCRIPTION
## Summary
- implement `crafting.py` with `Recipe` and sample recipes
- allow `Player` to craft items
- extend inventory UI with craft button and new `CraftingWindow`
- hook crafting window into main game loop
- test player crafting logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876ca4d6d2c8331a74313e0b458e844