### PR TITLE
Implement item credit exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ button to return to space.
   burst from the ship before settling in place, appear 15% larger and are 25%
   more numerous for better visibility.
 * Charge the **Ionized Symbiont** to fire a shot that latches onto enemy hulls and inflicts damage over time.
+* Stations let you exchange items for credits at 75% of their base value (Cosmic Guild members receive 10% extra).
 
 ### Defensive drones
 The Nebula Order flagship deploys a trio of small drones that protect only this

--- a/tests/test_station_exchange.py
+++ b/tests/test_station_exchange.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from character import Human, Player
+from fraction import FRACTIONS
+from station import EXCHANGE_RATE, SpaceStation
+
+
+def test_exchange_basic():
+    player = Player("Test", 20, Human(), FRACTIONS[0])
+    player.add_item("hierro", 2)
+    station = SpaceStation(0, 0)
+    gained = station.exchange_for_credits(player, "hierro", 2)
+    assert gained == int(5 * 2 * EXCHANGE_RATE)
+    assert player.credits == gained
+    assert player.inventory["hierro"] == 0
+
+
+def test_exchange_cosmic_bonus():
+    guild = next(f for f in FRACTIONS if f.name == "Cosmic Guild")
+    player = Player("Test", 20, Human(), guild)
+    player.add_item("hierro", 2)
+    station = SpaceStation(0, 0)
+    gained = station.exchange_for_credits(player, "hierro", 2)
+    assert gained == int(5 * 2 * EXCHANGE_RATE * 1.1)
+    assert player.credits == gained
+    assert player.inventory["hierro"] == 0


### PR DESCRIPTION
## Summary
- add `exchange_for_credits` with 75% base rate
- show exchange option in market UI
- document conversion rate in README
- test new station exchange logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876cdd549108331b62c860f93f922cc