### PR TITLE
Add refinery mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ button to return to space.
   more numerous for better visibility.
 * Charge the **Ionized Symbiont** to fire a shot that latches onto enemy hulls and inflicts damage over time.
 * Stations let you exchange items for credits at 75% of their base value (Cosmic Guild members receive 10% extra).
+* Refine ores into improved materials after researching **Ore Processing**.
 
 ### Defensive drones
 The Nebula Order flagship deploys a trio of small drones that protect only this
@@ -68,6 +69,12 @@ turret that fires spore bursts at enemies. The device only functions when a
 star is close enough for the Channeler to make contact. Connected turrets fire
 roughly once every 0.6&nbsp;seconds (around 100 shots per minute), but the rate
 drops to one shot every two seconds if the link is lost.
+
+### Refinery
+Researching the **Ore Processing** technology unlocks small refineries. These
+devices convert basic ores into refined components such as *lingote de hierro*
+and *placa de titanio*. Refining consumes the raw materials from your inventory
+and produces the improved goods.
 
 ## Character creation
 

--- a/src/character.py
+++ b/src/character.py
@@ -70,6 +70,19 @@ class Player:
         self.add_item(recipe.result, 1)
         return True
 
+    def refine_item(self, recipe: "RefineryRecipe") -> bool:
+        """Refine materials if the player knows ``Ore Processing``."""
+        from refinery import can_refine
+
+        if "Ore Processing" not in self.features:
+            return False
+        if not can_refine(self.inventory, recipe):
+            return False
+        for inp, out in recipe.mapping.items():
+            self.remove_item(inp)
+            self.add_item(out)
+        return True
+
     def progress_research(self, dt: float, bonus: float = 1.0) -> list[str]:
         """Advance research applying ``bonus`` and unlock completed techs."""
         finished = self.research.advance(dt, bonus)

--- a/src/items.py
+++ b/src/items.py
@@ -75,6 +75,8 @@ MATERIA_PRIMA: List[Item] = [
     Item("cromo", "materia_prima", 1.5, 15, "Metal brillante, resistente a la oxidación.", Rarity.COMUN),
     Item("vanadio", "materia_prima", 1.8, 25, "Metal de alta resistencia.", Rarity.POCO_COMUN),
     Item("molibdeno", "materia_prima", 2.0, 35, "Metal con alto punto de fusión.", Rarity.POCO_COMUN),
+    Item("lingote de hierro", "materia_prima", 2.5, 12, "Barra de hierro purificado.", Rarity.COMUN),
+    Item("placa de titanio", "materia_prima", 3.0, 25, "Lamina resistente de titanio procesado.", Rarity.POCO_COMUN),
 ]
 
 # --- Combustibles ----------------------------------------------------------

--- a/src/refinery.py
+++ b/src/refinery.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+from typing import Dict
+
+from items import ITEMS_BY_NAME
+
+
+@dataclass
+class RefineryRecipe:
+    """Recipe for refining raw materials into processed goods."""
+
+    mapping: Dict[str, str]
+    time: float = 0.0
+    energy: float = 0.0
+
+    def validate(self) -> None:
+        for inp, out in self.mapping.items():
+            if inp not in ITEMS_BY_NAME:
+                raise ValueError(f"Unknown input item: {inp}")
+            if out not in ITEMS_BY_NAME:
+                raise ValueError(f"Unknown output item: {out}")
+
+
+RECIPES = [
+    RefineryRecipe({"hierro": "lingote de hierro"}),
+    RefineryRecipe({"titanio": "placa de titanio"}),
+]
+
+for r in RECIPES:
+    r.validate()
+
+
+def can_refine(inventory: Dict[str, int], recipe: RefineryRecipe) -> bool:
+    """Return ``True`` if ``inventory`` has all required inputs for ``recipe``."""
+    return all(inventory.get(inp, 0) >= 1 for inp in recipe.mapping)
+
+
+def refine_item(player: "Player", recipe: RefineryRecipe) -> bool:
+    """Refine items according to ``recipe`` using ``player`` inventory."""
+    from character import Player  # local import to avoid circular dependency
+
+    if not can_refine(player.inventory, recipe):
+        return False
+    for inp, out in recipe.mapping.items():
+        player.remove_item(inp)
+        player.add_item(out)
+    return True

--- a/tests/test_refinery.py
+++ b/tests/test_refinery.py
@@ -1,0 +1,50 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from refinery import RECIPES
+from character import Player, Human
+from fraction import FRACTIONS
+from tech_tree import TECH_TREE
+
+
+def test_refine_success():
+    player = Player("Test", 20, Human(), FRACTIONS[0])
+    # unlock Ore Processing feature
+    player.research.start("mining")
+    player.progress_research(TECH_TREE["mining"].cost)
+
+    recipe = RECIPES[0]
+    for inp in recipe.mapping:
+        player.add_item(inp, 1)
+
+    assert player.refine_item(recipe)
+    for inp, out in recipe.mapping.items():
+        assert player.inventory[inp] == 0
+        assert player.inventory[out] == 1
+
+
+def test_refine_missing():
+    player = Player("Test", 20, Human(), FRACTIONS[0])
+    player.research.start("mining")
+    player.progress_research(TECH_TREE["mining"].cost)
+    recipe = RECIPES[0]
+    # do not add required input
+    assert not player.refine_item(recipe)
+    for inp, out in recipe.mapping.items():
+        assert player.inventory[inp] == 0
+        assert player.inventory[out] == 0
+
+
+def test_refine_requires_research():
+    player = Player("Test", 20, Human(), FRACTIONS[0])
+    recipe = RECIPES[0]
+    for inp in recipe.mapping:
+        player.add_item(inp, 1)
+    # feature not unlocked
+    assert not player.refine_item(recipe)
+    for inp, out in recipe.mapping.items():
+        assert player.inventory[inp] == 1
+        assert player.inventory[out] == 0
+


### PR DESCRIPTION
## Summary
- add new `RefineryRecipe` dataclass with helper functions
- allow players to refine items once "Ore Processing" is researched
- include refined materials in item catalogue
- document the refinery and research requirement
- test refinery behaviour

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68783108fd7883319463c75e281d94be