### PR TITLE
Enforce Ore Processing requirement in refinery

### DIFF
--- a/src/character.py
+++ b/src/character.py
@@ -71,17 +71,11 @@ class Player:
         return True
 
     def refine_item(self, recipe: "RefineryRecipe") -> bool:
-        """Refine materials if the player knows ``Ore Processing``."""
-        from refinery import can_refine
+        """Refine materials using :func:`refinery.refine_item`."""
+        import refinery as _refinery
 
-        if "Ore Processing" not in self.features:
-            return False
-        if not can_refine(self.inventory, recipe):
-            return False
-        for inp, out in recipe.mapping.items():
-            self.remove_item(inp)
-            self.add_item(out)
-        return True
+        # Delegate to the module helper so behaviour stays consistent
+        return _refinery.refine_item(self, recipe)
 
     def progress_research(self, dt: float, bonus: float = 1.0) -> list[str]:
         """Advance research applying ``bonus`` and unlock completed techs."""

--- a/src/refinery.py
+++ b/src/refinery.py
@@ -35,9 +35,16 @@ def can_refine(inventory: Dict[str, int], recipe: RefineryRecipe) -> bool:
 
 
 def refine_item(player: "Player", recipe: RefineryRecipe) -> bool:
-    """Refine items according to ``recipe`` using ``player`` inventory."""
+    """Refine items according to ``recipe`` using ``player`` inventory.
+
+    The player must have completed the ``Ore Processing`` research before any
+    refining can occur. This mirrors the behaviour of ``Player.refine_item``
+    and allows tests to invoke this helper directly.
+    """
     from character import Player  # local import to avoid circular dependency
 
+    if "Ore Processing" not in player.features:
+        return False
     if not can_refine(player.inventory, recipe):
         return False
     for inp, out in recipe.mapping.items():

--- a/tests/test_research_manager.py
+++ b/tests/test_research_manager.py
@@ -7,6 +7,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 from tech_tree import ResearchManager, TECH_TREE
 from character import Player, Human
 from fraction import FRACTIONS
+from refinery import RECIPES, refine_item
 
 
 def test_can_start_respects_prerequisites():
@@ -61,3 +62,20 @@ def test_bonus_speeds_up_research():
     finished = mgr.advance(TECH_TREE["mining"].cost / 2, bonus=2.0)
     assert "mining" in finished
     assert "mining" in mgr.completed
+
+
+def test_refinery_locked_until_research_completed():
+    player = Player("Test", 20, Human(), FRACTIONS[0])
+    recipe = RECIPES[0]
+
+    for inp in recipe.mapping:
+        player.add_item(inp, 1)
+
+    # Refining should fail before unlocking Ore Processing
+    assert not refine_item(player, recipe)
+
+    player.research.start("mining")
+    player.progress_research(TECH_TREE["mining"].cost)
+
+    # After completing the research, the helper should work
+    assert refine_item(player, recipe)


### PR DESCRIPTION
## Summary
- require the `Ore Processing` feature inside `refinery.refine_item`
- delegate `Player.refine_item` to the module helper
- verify refinery access in `tests/test_research_manager.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687832e0ee988331bb0cd73c0a941b97