### PR TITLE
Add quantity and research to crafting/refinery

### DIFF
--- a/data/crafting_recipes.json
+++ b/data/crafting_recipes.json
@@ -6,7 +6,9 @@
       "combustible ionico": 2
     },
     "time": 0,
-    "energy": 0
+    "energy": 0,
+    "quantity": 2,
+    "research": "Laser Cannons"
   },
   {
     "result": "lanzallamas",
@@ -15,7 +17,9 @@
       "combustible de fusion": 1
     },
     "time": 0,
-    "energy": 0
+    "energy": 0,
+    "quantity": 1,
+    "research": null
   },
   {
     "result": "moto antigravitatoria",
@@ -25,7 +29,9 @@
       "pico laser": 1
     },
     "time": 0,
-    "energy": 0
+    "energy": 0,
+    "quantity": 1,
+    "research": null
   },
   {
     "result": "generador de escudo",
@@ -34,6 +40,8 @@
       "cortador laser": 1
     },
     "time": 0,
-    "energy": 0
+    "energy": 0,
+    "quantity": 1,
+    "research": "Energy Shields"
   }
 ]

--- a/data/refinery_recipes.json
+++ b/data/refinery_recipes.json
@@ -4,13 +4,15 @@
       "hierro": "lingote de hierro"
     },
     "time": 0.0,
-    "energy": 0.0
+    "energy": 0.0,
+    "quantity": 2
   },
   {
     "mapping": {
       "titanio": "placa de titanio"
     },
     "time": 0.0,
-    "energy": 0.0
+    "energy": 0.0,
+    "quantity": 1
   }
 ]

--- a/src/character.py
+++ b/src/character.py
@@ -63,11 +63,11 @@ class Player:
         """Craft ``recipe.result`` consuming its ingredients if available."""
         from crafting import can_craft
 
-        if not can_craft(self.inventory, recipe):
+        if not can_craft(self.inventory, recipe, self.features):
             return False
         for name, qty in recipe.ingredients.items():
             self.remove_item(name, qty)
-        self.add_item(recipe.result, 1)
+        self.add_item(recipe.result, recipe.quantity)
         return True
 
     def refine_item(self, recipe: "RefineryRecipe") -> bool:

--- a/src/refinery.py
+++ b/src/refinery.py
@@ -13,6 +13,7 @@ class RefineryRecipe:
     mapping: Dict[str, str]
     time: float = 0.0
     energy: float = 0.0
+    quantity: int = 1
 
     def validate(self) -> None:
         for inp, out in self.mapping.items():
@@ -35,6 +36,7 @@ def _load_recipes() -> List[RefineryRecipe]:
             {k: v for k, v in entry["mapping"].items()},
             entry.get("time", 0.0),
             entry.get("energy", 0.0),
+            entry.get("quantity", 1),
         )
         recipe.validate()
         recipes.append(recipe)
@@ -64,5 +66,5 @@ def refine_item(player: "Player", recipe: RefineryRecipe) -> bool:
         return False
     for inp, out in recipe.mapping.items():
         player.remove_item(inp)
-        player.add_item(out)
+        player.add_item(out, recipe.quantity)
     return True

--- a/tests/test_crafting.py
+++ b/tests/test_crafting.py
@@ -12,10 +12,12 @@ from fraction import FRACTIONS
 def test_craft_item_success():
     player = Player("Test", 20, Human(), FRACTIONS[0])
     recipe = RECIPES[0]
+    if recipe.research:
+        player.features.add(recipe.research)
     for name, qty in recipe.ingredients.items():
         player.add_item(name, qty)
     assert player.craft_item(recipe)
-    assert player.inventory[recipe.result] == 1
+    assert player.inventory[recipe.result] == recipe.quantity
     for name in recipe.ingredients:
         assert player.inventory[name] == 0
 
@@ -23,8 +25,20 @@ def test_craft_item_success():
 def test_craft_item_missing():
     player = Player("Test", 20, Human(), FRACTIONS[0])
     recipe = RECIPES[1]
+    if recipe.research:
+        player.features.add(recipe.research)
     # add only part of ingredients
     for name, qty in list(recipe.ingredients.items())[:-1]:
         player.add_item(name, qty)
+    assert not player.craft_item(recipe)
+    assert player.inventory[recipe.result] == 0
+
+
+def test_craft_requires_research():
+    player = Player("Test", 20, Human(), FRACTIONS[0])
+    recipe = RECIPES[0]
+    for name, qty in recipe.ingredients.items():
+        player.add_item(name, qty)
+    # Feature not granted
     assert not player.craft_item(recipe)
     assert player.inventory[recipe.result] == 0

--- a/tests/test_refinery.py
+++ b/tests/test_refinery.py
@@ -22,7 +22,7 @@ def test_refine_success():
     assert player.refine_item(recipe)
     for inp, out in recipe.mapping.items():
         assert player.inventory[inp] == 0
-        assert player.inventory[out] == 1
+        assert player.inventory[out] == recipe.quantity
 
 
 def test_refine_missing():

--- a/tests/test_research_manager.py
+++ b/tests/test_research_manager.py
@@ -79,3 +79,6 @@ def test_refinery_locked_until_research_completed():
 
     # After completing the research, the helper should work
     assert refine_item(player, recipe)
+    for inp, out in recipe.mapping.items():
+        assert player.inventory[inp] == 0
+        assert player.inventory[out] == recipe.quantity


### PR DESCRIPTION
## Summary
- extend `Recipe`/`RefineryRecipe` with quantity and research fields
- enforce research requirements when crafting items
- output multiple items when crafting or refining
- update JSON recipe data with the new fields
- adjust tests for new behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68783c7a08888331996465a5fee7825e