### PR TITLE
Add ocean islands and water collectibles

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -597,6 +597,14 @@
       "rareza": "epico"
     },
     {
+      "nombre": "perla abisal",
+      "tipo": "objeto_raro",
+      "peso": 0.4,
+      "valor": 120,
+      "descripcion": "Perla que brilla en la oscuridad de las profundidades.",
+      "rareza": "epico"
+    },
+    {
       "nombre": "corazon de estrella",
       "tipo": "objeto_raro",
       "peso": 3.0,


### PR DESCRIPTION
## Summary
- allow ocean planets to generate small islands in `_generate_map`
- spawn special underwater pickups only reachable by boat
- add new item `perla abisal`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd53772fc833198762c0139505faf