### PR TITLE
Add toxic planet hazards

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -311,6 +311,14 @@
         "valor": 12,
         "descripcion": "Flor que brilla en la oscuridad.",
         "rareza": "poco_comun"
+    },
+    {
+        "nombre": "residuo toxico",
+        "tipo": "materia_prima",
+        "peso": 0.5,
+        "valor": 18,
+        "descripcion": "Desecho peligroso recolectado en zonas toxicas.",
+        "rareza": "poco_comun"
     }
   ],
   "combustibles": [
@@ -1313,6 +1321,14 @@
       "valor": 45,
       "descripcion": "Multiplican la fuerza de las manos.",
       "rareza": "raro"
+    },
+    {
+      "nombre": "traje aislante",
+      "tipo": "herramienta",
+      "peso": 5.0,
+      "valor": 150,
+      "descripcion": "Protege al usuario de gases venenosos.",
+      "rareza": "poco_comun"
     }
   ],
   "piezas_nave": [

--- a/src/config.py
+++ b/src/config.py
@@ -44,6 +44,9 @@ LAVA_GEYSER_INTERVAL_MIN = 4.0  # minimum seconds between geyser eruptions
 LAVA_GEYSER_INTERVAL_MAX = 8.0  # maximum seconds between geyser eruptions
 LAVA_GEYSER_DURATION = 1.5       # duration of an eruption in seconds
 LAVA_GEYSER_DAMAGE = 40          # damage per second from erupting geysers
+TOXIC_GAS_COLOR = (100, 150, 80, 150)  # RGBA colour for poisonous clouds
+TOXIC_GAS_DAMAGE = 15            # damage per second inside toxic gas
+RESIDUE_EXTRACTION_DAMAGE = 10   # health lost when harvesting toxic waste
 
 ORBIT_SPEED_FACTOR = 0.005  # base factor used to calculate orbital speed
 SHIP_ORBIT_SPEED = 1.5      # angular speed for attack orbits (radians per second)


### PR DESCRIPTION
## Summary
- spawn poisonous gas clouds and waste deposits on toxic planets
- check for a protective suit when updating the Explorer
- damage Explorer when exposed to gas or collecting waste
- add hazardous waste and protective suit items
- define new config constants for toxic hazards

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bdde3f61c8331a2241ebb156f4f24