### PR TITLE
Add diving suit and underwater biome features

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -731,6 +731,14 @@
       "valor": 115,
       "descripcion": "Resuena con melodías del universo.",
       "rareza": "raro"
+    },
+    {
+      "nombre": "coral brillante",
+      "tipo": "objeto_raro",
+      "peso": 0.2,
+      "valor": 90,
+      "descripcion": "Fragmento vivo de arrecife que emite luz.",
+      "rareza": "poco_comun"
     }
   ],
   "artefactos": [
@@ -1328,6 +1336,14 @@
       "peso": 5.0,
       "valor": 150,
       "descripcion": "Protege al usuario de gases venenosos.",
+      "rareza": "poco_comun"
+    },
+    {
+      "nombre": "traje de buceo",
+      "tipo": "herramienta",
+      "peso": 5.5,
+      "valor": 160,
+      "descripcion": "Permite explorar bajo el agua con comodidad.",
       "rareza": "poco_comun"
     }
   ],

--- a/src/biome.py
+++ b/src/biome.py
@@ -46,6 +46,20 @@ BIOMES: dict[str, Biome] = {
         0.15,
         1.3,
     ),
+    # Colourful reefs hiding unique resources
+    "coral reef": Biome(
+        (80, 150, 200),
+        ["coral brillante", "perla abisal"],
+        0.2,
+        1.1,
+    ),
+    # Darker deep sea trenches
+    "deep sea": Biome(
+        (20, 40, 90),
+        ["cristal de energia", "lagrima de sirena"],
+        0.12,
+        1.3,
+    ),
     # Default rocky surfaces
     "rocky": Biome(
         (110, 110, 110),

--- a/tests/test_diving_suit.py
+++ b/tests/test_diving_suit.py
@@ -1,0 +1,34 @@
+import types
+import pygame
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from planet_surface import PlanetSurface
+from character import Player, Human
+from fraction import FRACTIONS
+
+pygame.init()
+
+class DummyPlanet:
+    def __init__(self):
+        self.environment = "ocean world"
+        self.biomes = ["ocean world"]
+
+def test_diving_suit_allows_water_walk():
+    player = Player("Test", 20, Human(), FRACTIONS[0])
+    planet = DummyPlanet()
+    surface = PlanetSurface(planet, player)
+    # find a water cell
+    wx = wy = None
+    for x in range(0, surface.width, 30):
+        for y in range(0, surface.height, 30):
+            if surface.is_water(x, y):
+                wx, wy = x, y
+                break
+        if wx is not None:
+            break
+    assert wx is not None, "no water found"
+    assert not surface.is_walkable(wx, wy)
+    player.add_item("traje de buceo")
+    assert surface.is_walkable(wx, wy)


### PR DESCRIPTION
## Summary
- add `traje de buceo` equipment and new `coral brillante` pickup
- define `coral reef` and `deep sea` biomes
- allow walking in water when the player owns a diving suit
- generate special underwater biomes, pickups and creatures on ocean planets
- test that the diving suit allows underwater traversal

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c0f4ac72c83319730187db6b3456c